### PR TITLE
feat: Implement CRUD UseCases for Project Members and Roles

### DIFF
--- a/data/src/main/java/com/example/data/datasource/remote/projectmember/ProjectMemberRemoteDataSource.kt
+++ b/data/src/main/java/com/example/data/datasource/remote/projectmember/ProjectMemberRemoteDataSource.kt
@@ -21,6 +21,14 @@ interface ProjectMemberRemoteDataSource {
      * @return 프로젝트 멤버 목록의 Flow
      */
     fun getProjectMembersStream(projectId: String): Flow<List<ProjectMember>>
+
+    /**
+     * 특정 프로젝트의 특정 멤버 정보를 가져옵니다.
+     * @param projectId 프로젝트 ID
+     * @param userId 사용자 ID
+     * @return 프로젝트 멤버 정보 또는 null (에러 발생 시 Result.failure)
+     */
+    suspend fun getProjectMember(projectId: String, userId: String): Result<ProjectMember?>
     
     /**
      * 프로젝트에 새 멤버를 추가합니다.

--- a/data/src/main/java/com/example/data/datasource/remote/projectrole/ProjectRoleRemoteDataSource.kt
+++ b/data/src/main/java/com/example/data/datasource/remote/projectrole/ProjectRoleRemoteDataSource.kt
@@ -32,42 +32,49 @@ interface ProjectRoleRemoteDataSource {
     
     /**
      * 특정 역할의 상세 정보를 가져옵니다.
-     * @param roleId 역할 ID
-     * @return 역할 이름과 권한 맵 Pair 또는 에러
+     * @param projectId 프로젝트 ID
+     * @param roleId 역할 ID (실제 문서 ID)
+     * @return 역할 정보 또는 null (에러 발생 시 Result.failure)
      */
-    suspend fun getRoleDetails(roleId: String): Result<Pair<String, Map<RolePermission, Boolean>>>
+    suspend fun getRoleDetails(projectId: String, roleId: String): Result<Role?>
     
     /**
      * 새 역할을 생성합니다.
      * @param projectId 프로젝트 ID
      * @param name 역할 이름
      * @param permissions 권한 맵
+     * @param isDefault 기본 역할 여부
      * @return 새로 생성된 역할 ID
      */
     suspend fun createRole(
         projectId: String,
         name: String,
-        permissions: Map<RolePermission, Boolean>
+        permissions: Map<RolePermission, Boolean>,
+        isDefault: Boolean
     ): Result<String>
     
     /**
      * 역할을 업데이트합니다.
+     * @param projectId 프로젝트 ID
      * @param roleId 역할 ID
      * @param name 새 역할 이름
      * @param permissions 새 권한 맵
+     * @param isDefault 기본 역할 여부 (null이면 변경하지 않음)
      * @return 작업 성공 여부
      */
     suspend fun updateRole(
         projectId: String,
         roleId: String,
         name: String,
-        permissions: Map<RolePermission, Boolean>
+        permissions: Map<RolePermission, Boolean>,
+        isDefault: Boolean?
     ): Result<Unit>
     
     /**
      * 역할을 삭제합니다.
-     * @param roleId 역할 ID
+     * @param projectId 프로젝트 ID
+     * @param roleId 역할 ID (실제 문서 ID)
      * @return 작업 성공 여부
      */
-    suspend fun deleteRole(roleId: String): Result<Unit>
+    suspend fun deleteRole(projectId: String, roleId: String): Result<Unit>
 } 

--- a/data/src/main/java/com/example/data/repository/ProjectMemberRepositoryImpl.kt
+++ b/data/src/main/java/com/example/data/repository/ProjectMemberRepositoryImpl.kt
@@ -62,10 +62,10 @@ class ProjectMemberRepositoryImpl @Inject constructor(
         userId: String,
         forceRefresh: Boolean 
     ): Result<ProjectMember?> {
-        val result = remoteDataSource.getProjectMembers(projectId)
-        return result.map { members ->
-            members.find { it.userId == userId }
-        }
+        // The forceRefresh parameter is ignored as the remote data source's
+        // getProjectMember method does not support it directly.
+        // Firestore's caching mechanism handles data freshness.
+        return remoteDataSource.getProjectMember(projectId, userId)
     }
 
     /**

--- a/data/src/test/java/com/example/data/datasource/remote/projectmember/ProjectMemberRemoteDataSourceImplTest.kt
+++ b/data/src/test/java/com/example/data/datasource/remote/projectmember/ProjectMemberRemoteDataSourceImplTest.kt
@@ -1,0 +1,240 @@
+package com.example.data.datasource.remote.projectmember
+
+import com.example.core_common.constants.FirestoreConstants
+import com.example.core_common.util.DateTimeUtil
+import com.google.android.gms.tasks.Task
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.FieldValue
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mock
+import org.mockito.Mockito.*
+import org.mockito.MockitoAnnotations
+import kotlin.Result
+import org.junit.Assert.*
+import java.util.Date
+
+@ExperimentalCoroutinesApi
+class ProjectMemberRemoteDataSourceImplTest {
+
+    @Mock
+    private lateinit var firestore: FirebaseFirestore
+    @Mock
+    private lateinit var auth: FirebaseAuth
+    @Mock
+    private lateinit var mockFirebaseUser: FirebaseUser
+
+    @Mock
+    private lateinit var projectsCollectionRef: CollectionReference
+    @Mock
+    private lateinit var projectDocRef: DocumentReference
+    @Mock
+    private lateinit var membersCollectionRef: CollectionReference
+    @Mock
+    private lateinit var memberDocRef: DocumentReference
+    @Mock
+    private lateinit var usersCollectionRef: CollectionReference
+    @Mock
+    private lateinit var userDocRef: DocumentReference
+
+    @Mock
+    private lateinit var projectSnapshot: DocumentSnapshot
+    @Mock
+    private lateinit var voidTask: Task<Void>
+    @Mock
+    private lateinit var docTask: Task<DocumentSnapshot>
+
+
+    private lateinit var projectMemberRemoteDataSource: ProjectMemberRemoteDataSourceImpl
+
+    private val testProjectId = "testProject1"
+    private val testUserId = "testUser1"
+    private val testOwnerId = "ownerUser"
+    private val testNonOwnerId = "nonOwnerUser"
+    private val testRoleIds = listOf("role1")
+    private val now = DateTimeUtil.nowInstant()
+    private val firebaseTimestamp = DateTimeUtil.instantToFirebaseTimestamp(now)
+
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        projectMemberRemoteDataSource = ProjectMemberRemoteDataSourceImpl(firestore, auth)
+
+        // Common mock setups
+        `when`(auth.currentUser).thenReturn(mockFirebaseUser)
+
+        `when`(firestore.collection(FirestoreConstants.Collections.PROJECTS)).thenReturn(projectsCollectionRef)
+        `when`(projectsCollectionRef.document(testProjectId)).thenReturn(projectDocRef)
+
+        `when`(projectDocRef.collection(FirestoreConstants.Collections.MEMBERS)).thenReturn(membersCollectionRef)
+        `when`(membersCollectionRef.document(testUserId)).thenReturn(memberDocRef)
+        
+        `when`(firestore.collection(FirestoreConstants.Collections.USERS)).thenReturn(usersCollectionRef)
+        `when`(usersCollectionRef.document(testUserId)).thenReturn(userDocRef)
+        `when`(usersCollectionRef.document(testOwnerId)).thenReturn(userDocRef) // For owner check
+
+        // Mock Task<Void> for set, update, delete operations
+        `when`(voidTask.isSuccessful).thenReturn(true)
+        `when`(voidTask.isComplete).thenReturn(true)
+        // Suppress unchecked cast warning for Task<Void>
+        `when`(memberDocRef.set(anyMap<String, Any>())).thenReturn(voidTask as Task<Void>)
+        `when`(userDocRef.update(anyString(), any())).thenReturn(voidTask as Task<Void>)
+        `when`(projectDocRef.update(anyString(), any())).thenReturn(voidTask as Task<Void>)
+        `when`(memberDocRef.delete()).thenReturn(voidTask as Task<Void>)
+        
+        // Mock Task<DocumentSnapshot> for get operations
+        `when`(docTask.isSuccessful).thenReturn(true)
+        `when`(docTask.isComplete).thenReturn(true)
+        `when`(projectDocRef.get()).thenReturn(docTask as Task<DocumentSnapshot>)
+        `when`(docTask.result).thenReturn(projectSnapshot)
+    }
+
+    // --- addMemberToProject Tests ---
+    @Test
+    fun `addMemberToProject success by owner should update project memberIds`() = runTest {
+        // Arrange
+        `when`(mockFirebaseUser.uid).thenReturn(testOwnerId)
+        `when`(projectSnapshot.exists()).thenReturn(true)
+        `when`(projectSnapshot.getString(FirestoreConstants.ProjectFields.OWNER_ID)).thenReturn(testOwnerId)
+
+        val memberData = hashMapOf(
+            FirestoreConstants.MemberFields.ROLE_IDS to testRoleIds,
+            FirestoreConstants.MemberFields.JOINED_AT to firebaseTimestamp, // Expected value
+            FirestoreConstants.MemberFields.CHANNEL_IDS to emptyList<String>()
+        )
+        // Use argThat for map comparison if exact timestamp is tricky
+        `when`(memberDocRef.set(argThat<Map<String, Any>> { map ->
+            map[FirestoreConstants.MemberFields.ROLE_IDS] == testRoleIds &&
+            map[FirestoreConstants.MemberFields.CHANNEL_IDS] == emptyList<String>() &&
+            map.containsKey(FirestoreConstants.MemberFields.JOINED_AT) // Check presence of JOINED_AT
+        })).thenReturn(voidTask)
+
+
+        // Act
+        val result = projectMemberRemoteDataSource.addMemberToProject(testProjectId, testUserId, testRoleIds)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        verify(memberDocRef).set(argThat<Map<String, Any>> { map ->
+            map[FirestoreConstants.MemberFields.ROLE_IDS] == testRoleIds &&
+            map.containsKey(FirestoreConstants.MemberFields.JOINED_AT)
+        })
+        verify(userDocRef).update(FirestoreConstants.UserFields.PARTICIPATING_PROJECT_IDS, FieldValue.arrayUnion(testProjectId))
+        verify(projectDocRef).update(FirestoreConstants.ProjectFields.MEMBER_IDS, FieldValue.arrayUnion(testUserId))
+    }
+
+    @Test
+    fun `addMemberToProject failure if not owner`() = runTest {
+        // Arrange
+        `when`(mockFirebaseUser.uid).thenReturn(testNonOwnerId) // Current user is not the owner
+        `when`(projectSnapshot.exists()).thenReturn(true)
+        `when`(projectSnapshot.getString(FirestoreConstants.ProjectFields.OWNER_ID)).thenReturn(testOwnerId)
+
+        // Act
+        val result = projectMemberRemoteDataSource.addMemberToProject(testProjectId, testUserId, testRoleIds)
+
+        // Assert
+        assertTrue(result.isFailure)
+        assertEquals("멤버를 추가할 권한이 없습니다.", result.exceptionOrNull()?.message)
+        verify(memberDocRef, never()).set(any())
+        verify(projectDocRef, never()).update(FirestoreConstants.ProjectFields.MEMBER_IDS, FieldValue.arrayUnion(testUserId))
+    }
+    
+    @Test
+    fun `addMemberToProject failure if project does not exist`() = runTest {
+        // Arrange
+        `when`(mockFirebaseUser.uid).thenReturn(testOwnerId)
+        `when`(projectSnapshot.exists()).thenReturn(false) // Project does not exist
+
+        // Act
+        val result = projectMemberRemoteDataSource.addMemberToProject(testProjectId, testUserId, testRoleIds)
+
+        // Assert
+        assertTrue(result.isFailure)
+        assertEquals("존재하지 않는 프로젝트입니다.", result.exceptionOrNull()?.message)
+        verify(memberDocRef, never()).set(any())
+        verify(projectDocRef, never()).update(FirestoreConstants.ProjectFields.MEMBER_IDS, FieldValue.arrayUnion(testUserId))
+    }
+
+
+    // --- removeMemberFromProject Tests ---
+    @Test
+    fun `removeMemberFromProject success by owner should update project memberIds`() = runTest {
+        // Arrange
+        `when`(mockFirebaseUser.uid).thenReturn(testOwnerId)
+        `when`(projectSnapshot.exists()).thenReturn(true)
+        `when`(projectSnapshot.getString(FirestoreConstants.ProjectFields.OWNER_ID)).thenReturn(testOwnerId)
+
+        // Act
+        val result = projectMemberRemoteDataSource.removeMemberFromProject(testProjectId, testUserId)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        verify(memberDocRef).delete()
+        verify(userDocRef).update(FirestoreConstants.UserFields.PARTICIPATING_PROJECT_IDS, FieldValue.arrayRemove(testProjectId))
+        verify(projectDocRef).update(FirestoreConstants.ProjectFields.MEMBER_IDS, FieldValue.arrayRemove(testUserId))
+    }
+
+    @Test
+    fun `removeMemberFromProject failure if not owner`() = runTest {
+        // Arrange
+        `when`(mockFirebaseUser.uid).thenReturn(testNonOwnerId) // Current user is not owner
+        `when`(projectSnapshot.exists()).thenReturn(true)
+        `when`(projectSnapshot.getString(FirestoreConstants.ProjectFields.OWNER_ID)).thenReturn(testOwnerId)
+
+        // Act
+        val result = projectMemberRemoteDataSource.removeMemberFromProject(testProjectId, testUserId)
+
+        // Assert
+        assertTrue(result.isFailure)
+        assertEquals("멤버를 제거할 권한이 없습니다.", result.exceptionOrNull()?.message)
+        verify(memberDocRef, never()).delete()
+        verify(projectDocRef, never()).update(FirestoreConstants.ProjectFields.MEMBER_IDS, FieldValue.arrayRemove(testUserId))
+    }
+    
+    @Test
+    fun `removeMemberFromProject failure if trying to remove owner`() = runTest {
+        // Arrange
+        `when`(mockFirebaseUser.uid).thenReturn(testOwnerId)
+        `when`(projectSnapshot.exists()).thenReturn(true)
+        `when`(projectSnapshot.getString(FirestoreConstants.ProjectFields.OWNER_ID)).thenReturn(testOwnerId)
+
+        // Act
+        val result = projectMemberRemoteDataSource.removeMemberFromProject(testProjectId, testOwnerId) // Trying to remove self as owner
+
+        // Assert
+        assertTrue(result.isFailure)
+        assertEquals("프로젝트 소유자는 제거할 수 없습니다.", result.exceptionOrNull()?.message)
+        verify(memberDocRef, never()).delete()
+        verify(projectDocRef, never()).update(FirestoreConstants.ProjectFields.MEMBER_IDS, FieldValue.arrayRemove(testOwnerId))
+    }
+
+    @Test
+    fun `removeMemberFromProject failure if project does not exist`() = runTest {
+        // Arrange
+        `when`(mockFirebaseUser.uid).thenReturn(testOwnerId)
+        `when`(projectSnapshot.exists()).thenReturn(false) // Project does not exist
+
+        // Act
+        val result = projectMemberRemoteDataSource.removeMemberFromProject(testProjectId, testUserId)
+
+        // Assert
+        assertTrue(result.isFailure)
+        assertEquals("존재하지 않는 프로젝트입니다.", result.exceptionOrNull()?.message)
+        verify(memberDocRef, never()).delete()
+        verify(projectDocRef, never()).update(FirestoreConstants.ProjectFields.MEMBER_IDS, FieldValue.arrayRemove(testUserId))
+    }
+    
+    // Helper to mock Task<Void> for chained calls like .set().await()
+    private fun <T> anyMap(): Map<T, T> = any()
+}

--- a/data/src/test/java/com/example/data/repository/ProjectMemberRepositoryImplTest.kt
+++ b/data/src/test/java/com/example/data/repository/ProjectMemberRepositoryImplTest.kt
@@ -1,0 +1,81 @@
+package com.example.data.repository
+
+import com.example.data.datasource.remote.projectmember.ProjectMemberRemoteDataSource
+import com.example.domain.model.ProjectMember
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import kotlin.Result
+import org.junit.Assert.*
+
+@ExperimentalCoroutinesApi
+class ProjectMemberRepositoryImplTest {
+
+    @Mock
+    private lateinit var remoteDataSource: ProjectMemberRemoteDataSource
+
+    private lateinit var projectMemberRepository: ProjectMemberRepositoryImpl
+
+    private val testProjectId = "testProject1"
+    private val testUserId = "testUser1"
+    private val testMember = ProjectMember(
+        userId = testUserId,
+        userName = "Test User",
+        profileImageUrl = null,
+        roleIds = listOf("role1"),
+        joinedAt = System.currentTimeMillis()
+    )
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        projectMemberRepository = ProjectMemberRepositoryImpl(remoteDataSource)
+    }
+
+    @Test
+    fun `getProjectMember success should return member from remote data source`() = runTest {
+        // Arrange
+        `when`(remoteDataSource.getProjectMember(testProjectId, testUserId))
+            .thenReturn(Result.success(testMember))
+
+        // Act
+        val result = projectMemberRepository.getProjectMember(testProjectId, testUserId)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        assertEquals(testMember, result.getOrNull())
+    }
+
+    @Test
+    fun `getProjectMember when remote data source returns null should return success with null`() = runTest {
+        // Arrange
+        `when`(remoteDataSource.getProjectMember(testProjectId, testUserId))
+            .thenReturn(Result.success(null))
+
+        // Act
+        val result = projectMemberRepository.getProjectMember(testProjectId, testUserId)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        assertNull(result.getOrNull())
+    }
+
+    @Test
+    fun `getProjectMember failure should return failure from remote data source`() = runTest {
+        // Arrange
+        val exception = RuntimeException("Network error")
+        `when`(remoteDataSource.getProjectMember(testProjectId, testUserId))
+            .thenReturn(Result.failure(exception))
+
+        // Act
+        val result = projectMemberRepository.getProjectMember(testProjectId, testUserId)
+
+        // Assert
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+    }
+}

--- a/data/src/test/java/com/example/data/repository/ProjectRoleRepositoryImplTest.kt
+++ b/data/src/test/java/com/example/data/repository/ProjectRoleRepositoryImplTest.kt
@@ -1,0 +1,200 @@
+package com.example.data.repository
+
+import com.example.data.datasource.remote.projectrole.ProjectRoleRemoteDataSource
+import com.example.domain.model.Role
+import com.example.domain.model.RolePermission
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.verify
+import org.mockito.MockitoAnnotations
+import kotlin.Result
+import org.junit.Assert.*
+
+@ExperimentalCoroutinesApi
+class ProjectRoleRepositoryImplTest {
+
+    @Mock
+    private lateinit var remoteDataSource: ProjectRoleRemoteDataSource
+
+    private lateinit var projectRoleRepository: ProjectRoleRepositoryImpl
+
+    private val testProjectId = "testProject1"
+    private val testRoleId = "testRole1"
+    private val testRoleName = "Test Role"
+    private val testPermissions = mapOf(RolePermission.MANAGE_ROLES to true)
+    private val testIsDefault = false
+
+    private val testRole = Role(
+        id = testRoleId,
+        projectId = testProjectId,
+        name = testRoleName,
+        permissions = testPermissions,
+        isDefault = testIsDefault,
+        memberCount = 0
+    )
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        projectRoleRepository = ProjectRoleRepositoryImpl(remoteDataSource)
+    }
+
+    // Test for getRoleDetails
+    @Test
+    fun `getRoleDetails success should return role from remote data source`() = runTest {
+        // Arrange
+        `when`(remoteDataSource.getRoleDetails(testProjectId, testRoleId))
+            .thenReturn(Result.success(testRole))
+
+        // Act
+        val result = projectRoleRepository.getRoleDetails(testProjectId, testRoleId)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        assertEquals(testRole, result.getOrNull())
+        verify(remoteDataSource).getRoleDetails(testProjectId, testRoleId)
+    }
+
+    @Test
+    fun `getRoleDetails when remote data source returns null should return success with null`() = runTest {
+        // Arrange
+        `when`(remoteDataSource.getRoleDetails(testProjectId, testRoleId))
+            .thenReturn(Result.success(null))
+
+        // Act
+        val result = projectRoleRepository.getRoleDetails(testProjectId, testRoleId)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        assertNull(result.getOrNull())
+    }
+
+    @Test
+    fun `getRoleDetails failure should return failure from remote data source`() = runTest {
+        // Arrange
+        val exception = RuntimeException("Network error")
+        `when`(remoteDataSource.getRoleDetails(testProjectId, testRoleId))
+            .thenReturn(Result.failure(exception))
+
+        // Act
+        val result = projectRoleRepository.getRoleDetails(testProjectId, testRoleId)
+
+        // Assert
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+    }
+
+    // Test for createRole
+    @Test
+    fun `createRole success should return role ID from remote data source`() = runTest {
+        // Arrange
+        `when`(remoteDataSource.createRole(testProjectId, testRoleName, testPermissions, testIsDefault))
+            .thenReturn(Result.success(testRoleId))
+
+        // Act
+        val result = projectRoleRepository.createRole(testProjectId, testRoleName, testPermissions, testIsDefault)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        assertEquals(testRoleId, result.getOrNull())
+        verify(remoteDataSource).createRole(testProjectId, testRoleName, testPermissions, testIsDefault)
+    }
+
+    @Test
+    fun `createRole failure should return failure from remote data source`() = runTest {
+        // Arrange
+        val exception = RuntimeException("Create error")
+        `when`(remoteDataSource.createRole(testProjectId, testRoleName, testPermissions, testIsDefault))
+            .thenReturn(Result.failure(exception))
+
+        // Act
+        val result = projectRoleRepository.createRole(testProjectId, testRoleName, testPermissions, testIsDefault)
+
+        // Assert
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+    }
+
+    // Test for updateRole
+    @Test
+    fun `updateRole success should return success from remote data source`() = runTest {
+        // Arrange
+        val updatedName = "Updated Role Name"
+        val updatedPermissions = mapOf(RolePermission.MANAGE_MEMBERS to true)
+        val updatedIsDefault = true
+        `when`(remoteDataSource.updateRole(testProjectId, testRoleId, updatedName, updatedPermissions, updatedIsDefault))
+            .thenReturn(Result.success(Unit))
+
+        // Act
+        val result = projectRoleRepository.updateRole(testProjectId, testRoleId, updatedName, updatedPermissions, updatedIsDefault)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        verify(remoteDataSource).updateRole(testProjectId, testRoleId, updatedName, updatedPermissions, updatedIsDefault)
+    }
+
+    @Test
+    fun `updateRole failure should return failure from remote data source`() = runTest {
+        // Arrange
+        val exception = RuntimeException("Update error")
+        `when`(remoteDataSource.updateRole(testProjectId, testRoleId, testRoleName, testPermissions, testIsDefault))
+            .thenReturn(Result.failure(exception))
+
+        // Act
+        val result = projectRoleRepository.updateRole(testProjectId, testRoleId, testRoleName, testPermissions, testIsDefault)
+
+        // Assert
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+    }
+    
+    // Test for updateRole with nullable isDefault
+    @Test
+    fun `updateRole with null isDefault success should call remote with null isDefault`() = runTest {
+        // Arrange
+        `when`(remoteDataSource.updateRole(testProjectId, testRoleId, testRoleName, testPermissions, null))
+            .thenReturn(Result.success(Unit))
+
+        // Act
+        val result = projectRoleRepository.updateRole(testProjectId, testRoleId, testRoleName, testPermissions, null)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        verify(remoteDataSource).updateRole(testProjectId, testRoleId, testRoleName, testPermissions, null)
+    }
+
+
+    // Test for deleteRole
+    @Test
+    fun `deleteRole success should return success from remote data source`() = runTest {
+        // Arrange
+        `when`(remoteDataSource.deleteRole(testProjectId, testRoleId))
+            .thenReturn(Result.success(Unit))
+
+        // Act
+        val result = projectRoleRepository.deleteRole(testProjectId, testRoleId)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        verify(remoteDataSource).deleteRole(testProjectId, testRoleId)
+    }
+
+    @Test
+    fun `deleteRole failure should return failure from remote data source`() = runTest {
+        // Arrange
+        val exception = RuntimeException("Delete error")
+        `when`(remoteDataSource.deleteRole(testProjectId, testRoleId))
+            .thenReturn(Result.failure(exception))
+
+        // Act
+        val result = projectRoleRepository.deleteRole(testProjectId, testRoleId)
+
+        // Assert
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+    }
+}

--- a/domain/src/main/java/com/example/domain/model/ProjectMember.kt
+++ b/domain/src/main/java/com/example/domain/model/ProjectMember.kt
@@ -4,6 +4,7 @@ data class ProjectMember(
     val userId: String,
     val userName: String,
     val profileImageUrl: String?,
-    val roleIds: List<String> // 멤버가 가진 역할 ID 목록
+    val roleIds: List<String>, // 멤버가 가진 역할 ID 목록
+    val joinedAt: Long
     // 필요시 상태(온라인/오프라인) 등 추가
 )

--- a/domain/src/main/java/com/example/domain/model/Role.kt
+++ b/domain/src/main/java/com/example/domain/model/Role.kt
@@ -9,6 +9,7 @@ data class Role(
     val projectId: String, // 역할이 속한 프로젝트 ID
     val name: String, // 역할 이름
     val permissions: Map<RolePermission, Boolean>, // 각 권한(Enum)의 보유 여부
-    val memberCount: Int? = null // 이 역할을 가진 멤버 수 (선택적)
+    val memberCount: Int? = null, // 이 역할을 가진 멤버 수 (선택적)
+    val isDefault: Boolean = false // 기본 역할 여부
     // 필요시 역할 색상 등 추가
 )

--- a/domain/src/main/java/com/example/domain/model/project/MemberSortOption.kt
+++ b/domain/src/main/java/com/example/domain/model/project/MemberSortOption.kt
@@ -1,0 +1,11 @@
+package com.example.domain.model.project
+
+/**
+ * Enum class for specifying sorting options for project members.
+ */
+enum class MemberSortOption {
+    NAME_ASC,
+    NAME_DESC,
+    JOINED_AT_ASC,
+    JOINED_AT_DESC
+}

--- a/domain/src/main/java/com/example/domain/model/project/RoleSortOption.kt
+++ b/domain/src/main/java/com/example/domain/model/project/RoleSortOption.kt
@@ -1,0 +1,10 @@
+package com.example.domain.model.project
+
+/**
+ * Enum class for specifying sorting options for project roles.
+ */
+enum class RoleSortOption {
+    NAME_ASC,
+    NAME_DESC
+    // Add MEMBER_COUNT_ASC, MEMBER_COUNT_DESC later if Role.memberCount becomes reliably sortable.
+}

--- a/domain/src/main/java/com/example/domain/repository/ProjectRoleRepository.kt
+++ b/domain/src/main/java/com/example/domain/repository/ProjectRoleRepository.kt
@@ -22,35 +22,40 @@ interface ProjectRoleRepository {
 
     /**
      * 특정 역할의 상세 정보(이름, 권한 맵) 가져오기
+     * @param projectId 프로젝트 ID
      * @param roleId 역할 ID
-     * @return 역할 이름과 권한 맵 Pair 또는 에러
+     * @return 역할 정보 또는 에러
      */
-    suspend fun getRoleDetails(roleId: String): Result<Pair<String, Map<RolePermission, Boolean>>>
+    suspend fun getRoleDetails(projectId: String, roleId: String): Result<Role?>
 
     /**
      * 새 역할 생성
      * @param projectId 역할이 생성될 프로젝트 ID
      * @param name 새 역할 이름
      * @param permissions 새 역할의 권한 맵
-     * @return 성공/실패 결과 (생성된 Role 객체를 반환할 수도 있음)
+     * @param isDefault 기본 역할 여부
+     * @return 생성된 역할 ID 또는 에러
      */
-    suspend fun createRole(projectId: String, name: String, permissions: Map<RolePermission, Boolean>): Result<Unit> // 또는 Result<Role>
+    suspend fun createRole(projectId: String, name: String, permissions: Map<RolePermission, Boolean>, isDefault: Boolean): Result<String>
 
     /**
      * 기존 역할 업데이트 (이름 또는 권한)
+     * @param projectId 프로젝트 ID
      * @param roleId 수정할 역할 ID
      * @param name 새 역할 이름
      * @param permissions 새 권한 맵
+     * @param isDefault 기본 역할 여부 (null이면 변경하지 않음)
      * @return 성공/실패 결과
      */
-    suspend fun updateRole(roleId: String, name: String, permissions: Map<RolePermission, Boolean>): Result<Unit>
+    suspend fun updateRole(projectId: String, roleId: String, name: String, permissions: Map<RolePermission, Boolean>, isDefault: Boolean?): Result<Unit>
 
     /**
      * 역할 삭제
+     * @param projectId 프로젝트 ID
      * @param roleId 삭제할 역할 ID
      * @return 성공/실패 결과
      */
-    suspend fun deleteRole(roleId: String): Result<Unit>
+    suspend fun deleteRole(projectId: String, roleId: String): Result<Unit>
 
     // TODO: 역할 순서 변경, 멤버에게 역할 할당/해제 등의 함수 필요 시 추가
 }

--- a/domain/src/main/java/com/example/domain/usecase/project/member/AddProjectMemberUseCase.kt
+++ b/domain/src/main/java/com/example/domain/usecase/project/member/AddProjectMemberUseCase.kt
@@ -1,0 +1,18 @@
+package com.example.domain.usecase.project.member
+
+import kotlin.Result
+
+/**
+ * UseCase for adding a member to a project.
+ */
+interface AddProjectMemberUseCase {
+    /**
+     * Adds a user to a project with the specified initial roles.
+     *
+     * @param projectId The ID of the project.
+     * @param userId The ID of the user to add.
+     * @param initialRoleIds The list of role IDs to assign to the member initially.
+     * @return A [Result] indicating success or failure.
+     */
+    suspend operator fun invoke(projectId: String, userId: String, initialRoleIds: List<String>): Result<Unit>
+}

--- a/domain/src/main/java/com/example/domain/usecase/project/member/AddProjectMemberUseCaseImpl.kt
+++ b/domain/src/main/java/com/example/domain/usecase/project/member/AddProjectMemberUseCaseImpl.kt
@@ -1,0 +1,29 @@
+package com.example.domain.usecase.project.member
+
+import com.example.domain.repository.ProjectMemberRepository
+import javax.inject.Inject
+import kotlin.Result
+
+/**
+ * Implementation of [AddProjectMemberUseCase].
+ */
+class AddProjectMemberUseCaseImpl @Inject constructor(
+    private val projectMemberRepository: ProjectMemberRepository
+) : AddProjectMemberUseCase {
+
+    /**
+     * Adds a user to a project with the specified initial roles.
+     *
+     * @param projectId The ID of the project.
+     * @param userId The ID of the user to add.
+     * @param initialRoleIds The list of role IDs to assign to the member initially.
+     * @return A [Result] indicating success or failure.
+     */
+    override suspend fun invoke(
+        projectId: String,
+        userId: String,
+        initialRoleIds: List<String>
+    ): Result<Unit> {
+        return projectMemberRepository.addMemberToProject(projectId, userId, initialRoleIds)
+    }
+}

--- a/domain/src/main/java/com/example/domain/usecase/project/member/GetMembersInRoleUseCase.kt
+++ b/domain/src/main/java/com/example/domain/usecase/project/member/GetMembersInRoleUseCase.kt
@@ -1,0 +1,18 @@
+package com.example.domain.usecase.project.member
+
+import com.example.domain.model.ProjectMember
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * UseCase for retrieving all members assigned to a specific role within a project.
+ */
+interface GetMembersInRoleUseCase {
+    /**
+     * Retrieves a flow of project members who are assigned the specified role.
+     *
+     * @param projectId The ID of the project.
+     * @param roleId The ID of the role to filter members by.
+     * @return A [Flow] emitting a list of [ProjectMember] objects assigned to the role.
+     */
+    operator fun invoke(projectId: String, roleId: String): Flow<List<ProjectMember>>
+}

--- a/domain/src/main/java/com/example/domain/usecase/project/member/GetMembersInRoleUseCaseImpl.kt
+++ b/domain/src/main/java/com/example/domain/usecase/project/member/GetMembersInRoleUseCaseImpl.kt
@@ -1,0 +1,28 @@
+package com.example.domain.usecase.project.member
+
+import com.example.domain.model.ProjectMember
+import com.example.domain.repository.ProjectMemberRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+/**
+ * Implementation of [GetMembersInRoleUseCase].
+ */
+class GetMembersInRoleUseCaseImpl @Inject constructor(
+    private val projectMemberRepository: ProjectMemberRepository
+) : GetMembersInRoleUseCase {
+
+    /**
+     * Retrieves a flow of project members who are assigned the specified role.
+     *
+     * @param projectId The ID of the project.
+     * @param roleId The ID of the role to filter members by.
+     * @return A [Flow] emitting a list of [ProjectMember] objects assigned to the role.
+     */
+    override operator fun invoke(projectId: String, roleId: String): Flow<List<ProjectMember>> {
+        return projectMemberRepository.getProjectMembersStream(projectId).map { members ->
+            members.filter { it.roleIds.contains(roleId) }
+        }
+    }
+}

--- a/domain/src/main/java/com/example/domain/usecase/project/member/GetProjectMemberUseCase.kt
+++ b/domain/src/main/java/com/example/domain/usecase/project/member/GetProjectMemberUseCase.kt
@@ -1,0 +1,18 @@
+package com.example.domain.usecase.project.member
+
+import com.example.domain.model.ProjectMember
+import kotlin.Result
+
+/**
+ * UseCase for retrieving a specific project member.
+ */
+interface GetProjectMemberUseCase {
+    /**
+     * Retrieves a specific member from a project.
+     *
+     * @param projectId The ID of the project.
+     * @param userId The ID of the user (member) to retrieve.
+     * @return A [Result] containing the [ProjectMember] if found, or null if not found, or an error.
+     */
+    suspend operator fun invoke(projectId: String, userId: String): Result<ProjectMember?>
+}

--- a/domain/src/main/java/com/example/domain/usecase/project/member/GetProjectMemberUseCaseImpl.kt
+++ b/domain/src/main/java/com/example/domain/usecase/project/member/GetProjectMemberUseCaseImpl.kt
@@ -1,0 +1,27 @@
+package com.example.domain.usecase.project.member
+
+import com.example.domain.model.ProjectMember
+import com.example.domain.repository.ProjectMemberRepository
+import javax.inject.Inject
+import kotlin.Result
+
+/**
+ * Implementation of [GetProjectMemberUseCase].
+ */
+class GetProjectMemberUseCaseImpl @Inject constructor(
+    private val projectMemberRepository: ProjectMemberRepository
+) : GetProjectMemberUseCase {
+
+    /**
+     * Retrieves a specific member from a project.
+     *
+     * @param projectId The ID of the project.
+     * @param userId The ID of the user (member) to retrieve.
+     * @return A [Result] containing the [ProjectMember] if found, or null if not found, or an error.
+     */
+    override suspend fun invoke(projectId: String, userId: String): Result<ProjectMember?> {
+        // The repository's getProjectMember already handles forceRefresh if needed by its own logic.
+        // Here we directly call it.
+        return projectMemberRepository.getProjectMember(projectId, userId)
+    }
+}

--- a/domain/src/main/java/com/example/domain/usecase/project/member/GetProjectMembersUseCase.kt
+++ b/domain/src/main/java/com/example/domain/usecase/project/member/GetProjectMembersUseCase.kt
@@ -1,0 +1,24 @@
+package com.example.domain.usecase.project.member
+
+import com.example.domain.model.ProjectMember
+import com.example.domain.model.project.MemberSortOption
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * UseCase for retrieving a list of project members with optional filtering and sorting.
+ */
+interface GetProjectMembersUseCase {
+    /**
+     * Retrieves a flow of project members, with optional filtering by role and sorting.
+     *
+     * @param projectId The ID of the project.
+     * @param roleIdFilter Optional. If provided, only members with this role ID will be included.
+     * @param sortBy Optional. Specifies the sorting order for the members.
+     * @return A [Flow] emitting a list of [ProjectMember] objects.
+     */
+    operator fun invoke(
+        projectId: String,
+        roleIdFilter: String? = null,
+        sortBy: MemberSortOption? = null
+    ): Flow<List<ProjectMember>>
+}

--- a/domain/src/main/java/com/example/domain/usecase/project/member/GetProjectMembersUseCaseImpl.kt
+++ b/domain/src/main/java/com/example/domain/usecase/project/member/GetProjectMembersUseCaseImpl.kt
@@ -1,0 +1,46 @@
+package com.example.domain.usecase.project.member
+
+import com.example.domain.model.ProjectMember
+import com.example.domain.model.project.MemberSortOption
+import com.example.domain.repository.ProjectMemberRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+/**
+ * Implementation of [GetProjectMembersUseCase].
+ */
+class GetProjectMembersUseCaseImpl @Inject constructor(
+    private val projectMemberRepository: ProjectMemberRepository
+) : GetProjectMembersUseCase {
+
+    /**
+     * Retrieves a flow of project members, with optional filtering by role and sorting.
+     *
+     * @param projectId The ID of the project.
+     * @param roleIdFilter Optional. If provided, only members with this role ID will be included.
+     * @param sortBy Optional. Specifies the sorting order for the members.
+     * @return A [Flow] emitting a list of [ProjectMember] objects.
+     */
+    override operator fun invoke(
+        projectId: String,
+        roleIdFilter: String?,
+        sortBy: MemberSortOption?
+    ): Flow<List<ProjectMember>> {
+        return projectMemberRepository.getProjectMembersStream(projectId).map { members ->
+            val filteredMembers = if (roleIdFilter != null) {
+                members.filter { it.roleIds.contains(roleIdFilter) }
+            } else {
+                members
+            }
+
+            when (sortBy) {
+                MemberSortOption.NAME_ASC -> filteredMembers.sortedBy { it.userName.lowercase() }
+                MemberSortOption.NAME_DESC -> filteredMembers.sortedByDescending { it.userName.lowercase() }
+                MemberSortOption.JOINED_AT_ASC -> filteredMembers.sortedBy { it.joinedAt }
+                MemberSortOption.JOINED_AT_DESC -> filteredMembers.sortedByDescending { it.joinedAt }
+                null -> filteredMembers // No sorting
+            }
+        }
+    }
+}

--- a/domain/src/main/java/com/example/domain/usecase/project/member/RemoveProjectMemberUseCase.kt
+++ b/domain/src/main/java/com/example/domain/usecase/project/member/RemoveProjectMemberUseCase.kt
@@ -1,0 +1,17 @@
+package com.example.domain.usecase.project.member
+
+import kotlin.Result
+
+/**
+ * UseCase for removing a member from a project.
+ */
+interface RemoveProjectMemberUseCase {
+    /**
+     * Removes a user from a project.
+     *
+     * @param projectId The ID of the project.
+     * @param userId The ID of the user to remove.
+     * @return A [Result] indicating success or failure.
+     */
+    suspend operator fun invoke(projectId: String, userId: String): Result<Unit>
+}

--- a/domain/src/main/java/com/example/domain/usecase/project/member/RemoveProjectMemberUseCaseImpl.kt
+++ b/domain/src/main/java/com/example/domain/usecase/project/member/RemoveProjectMemberUseCaseImpl.kt
@@ -1,0 +1,24 @@
+package com.example.domain.usecase.project.member
+
+import com.example.domain.repository.ProjectMemberRepository
+import javax.inject.Inject
+import kotlin.Result
+
+/**
+ * Implementation of [RemoveProjectMemberUseCase].
+ */
+class RemoveProjectMemberUseCaseImpl @Inject constructor(
+    private val projectMemberRepository: ProjectMemberRepository
+) : RemoveProjectMemberUseCase {
+
+    /**
+     * Removes a user from a project.
+     *
+     * @param projectId The ID of the project.
+     * @param userId The ID of the user to remove.
+     * @return A [Result] indicating success or failure.
+     */
+    override suspend fun invoke(projectId: String, userId: String): Result<Unit> {
+        return projectMemberRepository.removeMemberFromProject(projectId, userId)
+    }
+}

--- a/domain/src/main/java/com/example/domain/usecase/project/member/UpdateProjectMemberUseCase.kt
+++ b/domain/src/main/java/com/example/domain/usecase/project/member/UpdateProjectMemberUseCase.kt
@@ -1,0 +1,27 @@
+package com.example.domain.usecase.project.member
+
+import kotlin.Result
+
+/**
+ * UseCase for updating a project member's roles and channel access.
+ */
+interface UpdateProjectMemberUseCase {
+    /**
+     * Updates a project member's roles and/or channel access.
+     *
+     * @param projectId The ID of the project.
+     * @param userId The ID of the user (member) to update.
+     * @param roleIds Optional. If provided, the member's roles will be updated to this list.
+     * @param channelIdsToAdd Optional. If provided, these channel IDs will be added to the member's accessible channels.
+     * @param channelIdsToRemove Optional. If provided, these channel IDs will be removed from the member's accessible channels.
+     * @return A [Result] indicating success or failure. If multiple operations are performed,
+     *         it returns the first failure or success if all operations succeed.
+     */
+    suspend operator fun invoke(
+        projectId: String,
+        userId: String,
+        roleIds: List<String>? = null,
+        channelIdsToAdd: List<String>? = null,
+        channelIdsToRemove: List<String>? = null
+    ): Result<Unit>
+}

--- a/domain/src/main/java/com/example/domain/usecase/project/member/UpdateProjectMemberUseCaseImpl.kt
+++ b/domain/src/main/java/com/example/domain/usecase/project/member/UpdateProjectMemberUseCaseImpl.kt
@@ -1,0 +1,59 @@
+package com.example.domain.usecase.project.member
+
+import com.example.domain.repository.ProjectMemberRepository
+import javax.inject.Inject
+import kotlin.Result
+
+/**
+ * Implementation of [UpdateProjectMemberUseCase].
+ */
+class UpdateProjectMemberUseCaseImpl @Inject constructor(
+    private val projectMemberRepository: ProjectMemberRepository
+) : UpdateProjectMemberUseCase {
+
+    /**
+     * Updates a project member's roles and/or channel access.
+     *
+     * @param projectId The ID of the project.
+     * @param userId The ID of the user (member) to update.
+     * @param roleIds Optional. If provided, the member's roles will be updated to this list.
+     * @param channelIdsToAdd Optional. If provided, these channel IDs will be added to the member's accessible channels.
+     * @param channelIdsToRemove Optional. If provided, these channel IDs will be removed from the member's accessible channels.
+     * @return A [Result] indicating success or failure. If multiple operations are performed,
+     *         it returns the first failure or success if all operations succeed.
+     */
+    override suspend fun invoke(
+        projectId: String,
+        userId: String,
+        roleIds: List<String>?,
+        channelIdsToAdd: List<String>?,
+        channelIdsToRemove: List<String>?
+    ): Result<Unit> {
+        try {
+            if (roleIds != null) {
+                val rolesUpdateResult = projectMemberRepository.updateMemberRoles(projectId, userId, roleIds)
+                if (rolesUpdateResult.isFailure) {
+                    return rolesUpdateResult // Propagate the failure
+                }
+            }
+
+            channelIdsToAdd?.forEach { channelId ->
+                val addAccessResult = projectMemberRepository.addChannelAccessToMember(projectId, userId, channelId)
+                if (addAccessResult.isFailure) {
+                    return addAccessResult // Propagate the failure
+                }
+            }
+
+            channelIdsToRemove?.forEach { channelId ->
+                val removeAccessResult = projectMemberRepository.removeChannelAccessFromMember(projectId, userId, channelId)
+                if (removeAccessResult.isFailure) {
+                    return removeAccessResult // Propagate the failure
+                }
+            }
+
+            return Result.success(Unit)
+        } catch (e: Exception) {
+            return Result.failure(e)
+        }
+    }
+}

--- a/domain/src/main/java/com/example/domain/usecase/project/role/CreateProjectRoleUseCase.kt
+++ b/domain/src/main/java/com/example/domain/usecase/project/role/CreateProjectRoleUseCase.kt
@@ -1,0 +1,25 @@
+package com.example.domain.usecase.project.role
+
+import com.example.domain.model.RolePermission
+import kotlin.Result
+
+/**
+ * UseCase for creating a new project role.
+ */
+interface CreateProjectRoleUseCase {
+    /**
+     * Creates a new role within a project.
+     *
+     * @param projectId The ID of the project.
+     * @param name The name of the new role.
+     * @param permissions The map of permissions for the new role.
+     * @param isDefault Whether the new role should be a default role. Defaults to false.
+     * @return A [Result] containing the ID of the newly created role, or an error.
+     */
+    suspend operator fun invoke(
+        projectId: String,
+        name: String,
+        permissions: Map<RolePermission, Boolean>,
+        isDefault: Boolean = false
+    ): Result<String>
+}

--- a/domain/src/main/java/com/example/domain/usecase/project/role/CreateProjectRoleUseCaseImpl.kt
+++ b/domain/src/main/java/com/example/domain/usecase/project/role/CreateProjectRoleUseCaseImpl.kt
@@ -1,0 +1,32 @@
+package com.example.domain.usecase.project.role
+
+import com.example.domain.model.RolePermission
+import com.example.domain.repository.ProjectRoleRepository
+import javax.inject.Inject
+import kotlin.Result
+
+/**
+ * Implementation of [CreateProjectRoleUseCase].
+ */
+class CreateProjectRoleUseCaseImpl @Inject constructor(
+    private val projectRoleRepository: ProjectRoleRepository
+) : CreateProjectRoleUseCase {
+
+    /**
+     * Creates a new role within a project.
+     *
+     * @param projectId The ID of the project.
+     * @param name The name of the new role.
+     * @param permissions The map of permissions for the new role.
+     * @param isDefault Whether the new role should be a default role. Defaults to false.
+     * @return A [Result] containing the ID of the newly created role, or an error.
+     */
+    override suspend operator fun invoke(
+        projectId: String,
+        name: String,
+        permissions: Map<RolePermission, Boolean>,
+        isDefault: Boolean
+    ): Result<String> {
+        return projectRoleRepository.createRole(projectId, name, permissions, isDefault)
+    }
+}

--- a/domain/src/main/java/com/example/domain/usecase/project/role/DeleteProjectRoleUseCase.kt
+++ b/domain/src/main/java/com/example/domain/usecase/project/role/DeleteProjectRoleUseCase.kt
@@ -1,0 +1,17 @@
+package com.example.domain.usecase.project.role
+
+import kotlin.Result
+
+/**
+ * UseCase for deleting a project role.
+ */
+interface DeleteProjectRoleUseCase {
+    /**
+     * Deletes an existing role from a project.
+     *
+     * @param projectId The ID of the project.
+     * @param roleId The ID of the role to delete.
+     * @return A [Result] indicating success or failure.
+     */
+    suspend operator fun invoke(projectId: String, roleId: String): Result<Unit>
+}

--- a/domain/src/main/java/com/example/domain/usecase/project/role/DeleteProjectRoleUseCaseImpl.kt
+++ b/domain/src/main/java/com/example/domain/usecase/project/role/DeleteProjectRoleUseCaseImpl.kt
@@ -1,0 +1,24 @@
+package com.example.domain.usecase.project.role
+
+import com.example.domain.repository.ProjectRoleRepository
+import javax.inject.Inject
+import kotlin.Result
+
+/**
+ * Implementation of [DeleteProjectRoleUseCase].
+ */
+class DeleteProjectRoleUseCaseImpl @Inject constructor(
+    private val projectRoleRepository: ProjectRoleRepository
+) : DeleteProjectRoleUseCase {
+
+    /**
+     * Deletes an existing role from a project.
+     *
+     * @param projectId The ID of the project.
+     * @param roleId The ID of the role to delete.
+     * @return A [Result] indicating success or failure.
+     */
+    override suspend operator fun invoke(projectId: String, roleId: String): Result<Unit> {
+        return projectRoleRepository.deleteRole(projectId, roleId)
+    }
+}

--- a/domain/src/main/java/com/example/domain/usecase/project/role/GetProjectRoleUseCase.kt
+++ b/domain/src/main/java/com/example/domain/usecase/project/role/GetProjectRoleUseCase.kt
@@ -1,0 +1,18 @@
+package com.example.domain.usecase.project.role
+
+import com.example.domain.model.Role
+import kotlin.Result
+
+/**
+ * UseCase for retrieving a specific project role.
+ */
+interface GetProjectRoleUseCase {
+    /**
+     * Retrieves a specific role from a project.
+     *
+     * @param projectId The ID of the project.
+     * @param roleId The ID of the role to retrieve.
+     * @return A [Result] containing the [Role] if found, or null if not found, or an error.
+     */
+    suspend operator fun invoke(projectId: String, roleId: String): Result<Role?>
+}

--- a/domain/src/main/java/com/example/domain/usecase/project/role/GetProjectRoleUseCaseImpl.kt
+++ b/domain/src/main/java/com/example/domain/usecase/project/role/GetProjectRoleUseCaseImpl.kt
@@ -1,0 +1,25 @@
+package com.example.domain.usecase.project.role
+
+import com.example.domain.model.Role
+import com.example.domain.repository.ProjectRoleRepository
+import javax.inject.Inject
+import kotlin.Result
+
+/**
+ * Implementation of [GetProjectRoleUseCase].
+ */
+class GetProjectRoleUseCaseImpl @Inject constructor(
+    private val projectRoleRepository: ProjectRoleRepository
+) : GetProjectRoleUseCase {
+
+    /**
+     * Retrieves a specific role from a project.
+     *
+     * @param projectId The ID of the project.
+     * @param roleId The ID of the role to retrieve.
+     * @return A [Result] containing the [Role] if found, or null if not found, or an error.
+     */
+    override suspend operator fun invoke(projectId: String, roleId: String): Result<Role?> {
+        return projectRoleRepository.getRoleDetails(projectId, roleId)
+    }
+}

--- a/domain/src/main/java/com/example/domain/usecase/project/role/GetProjectRolesUseCase.kt
+++ b/domain/src/main/java/com/example/domain/usecase/project/role/GetProjectRolesUseCase.kt
@@ -1,0 +1,24 @@
+package com.example.domain.usecase.project.role
+
+import com.example.domain.model.Role
+import com.example.domain.model.project.RoleSortOption
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * UseCase for retrieving a list of project roles with optional filtering and sorting.
+ */
+interface GetProjectRolesUseCase {
+    /**
+     * Retrieves a flow of project roles, with optional filtering by default status and sorting.
+     *
+     * @param projectId The ID of the project.
+     * @param filterIsDefault Optional. If provided, filters roles where `Role.isDefault` matches this value.
+     * @param sortBy Optional. Specifies the sorting order for the roles.
+     * @return A [Flow] emitting a list of [Role] objects.
+     */
+    operator fun invoke(
+        projectId: String,
+        filterIsDefault: Boolean? = null,
+        sortBy: RoleSortOption? = null
+    ): Flow<List<Role>>
+}

--- a/domain/src/main/java/com/example/domain/usecase/project/role/GetProjectRolesUseCaseImpl.kt
+++ b/domain/src/main/java/com/example/domain/usecase/project/role/GetProjectRolesUseCaseImpl.kt
@@ -1,0 +1,45 @@
+package com.example.domain.usecase.project.role
+
+import com.example.domain.model.Role
+import com.example.domain.model.project.RoleSortOption
+import com.example.domain.repository.ProjectRoleRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+/**
+ * Implementation of [GetProjectRolesUseCase].
+ */
+class GetProjectRolesUseCaseImpl @Inject constructor(
+    private val projectRoleRepository: ProjectRoleRepository
+) : GetProjectRolesUseCase {
+
+    /**
+     * Retrieves a flow of project roles, with optional filtering by default status and sorting.
+     *
+     * @param projectId The ID of the project.
+     * @param filterIsDefault Optional. If provided, filters roles where `Role.isDefault` matches this value.
+     * @param sortBy Optional. Specifies the sorting order for the roles.
+     * @return A [Flow] emitting a list of [Role] objects.
+     */
+    override operator fun invoke(
+        projectId: String,
+        filterIsDefault: Boolean?,
+        sortBy: RoleSortOption?
+    ): Flow<List<Role>> {
+        return projectRoleRepository.getRolesStream(projectId).map { roles ->
+            val filteredRoles = if (filterIsDefault != null) {
+                roles.filter { it.isDefault == filterIsDefault }
+            } else {
+                roles
+            }
+
+            when (sortBy) {
+                RoleSortOption.NAME_ASC -> filteredRoles.sortedBy { it.name.lowercase() }
+                RoleSortOption.NAME_DESC -> filteredRoles.sortedByDescending { it.name.lowercase() }
+                // Add other sort options like MEMBER_COUNT here if Role.memberCount is reliable
+                null -> filteredRoles // No sorting
+            }
+        }
+    }
+}

--- a/domain/src/main/java/com/example/domain/usecase/project/role/UpdateProjectRoleUseCase.kt
+++ b/domain/src/main/java/com/example/domain/usecase/project/role/UpdateProjectRoleUseCase.kt
@@ -1,0 +1,27 @@
+package com.example.domain.usecase.project.role
+
+import com.example.domain.model.RolePermission
+import kotlin.Result
+
+/**
+ * UseCase for updating a project role.
+ */
+interface UpdateProjectRoleUseCase {
+    /**
+     * Updates an existing role within a project.
+     *
+     * @param projectId The ID of the project.
+     * @param roleId The ID of the role to update.
+     * @param name Optional. The new name for the role. If null, the name is not changed.
+     * @param permissions Optional. The new permissions map for the role. If null, permissions are not changed.
+     * @param isDefault Optional. The new default status for the role. If null, the default status is not changed.
+     * @return A [Result] indicating success or failure.
+     */
+    suspend operator fun invoke(
+        projectId: String,
+        roleId: String,
+        name: String? = null,
+        permissions: Map<RolePermission, Boolean>? = null,
+        isDefault: Boolean? = null
+    ): Result<Unit>
+}

--- a/domain/src/main/java/com/example/domain/usecase/project/role/UpdateProjectRoleUseCaseImpl.kt
+++ b/domain/src/main/java/com/example/domain/usecase/project/role/UpdateProjectRoleUseCaseImpl.kt
@@ -1,0 +1,56 @@
+package com.example.domain.usecase.project.role
+
+import com.example.domain.model.RolePermission
+import com.example.domain.repository.ProjectRoleRepository
+import javax.inject.Inject
+import kotlin.Result
+
+/**
+ * Implementation of [UpdateProjectRoleUseCase].
+ */
+class UpdateProjectRoleUseCaseImpl @Inject constructor(
+    private val projectRoleRepository: ProjectRoleRepository
+) : UpdateProjectRoleUseCase {
+
+    /**
+     * Updates an existing role within a project.
+     *
+     * @param projectId The ID of the project.
+     * @param roleId The ID of the role to update.
+     * @param name Optional. The new name for the role. If null, the name is not changed.
+     * @param permissions Optional. The new permissions map for the role. If null, permissions are not changed.
+     * @param isDefault Optional. The new default status for the role. If null, the default status is not changed.
+     * @return A [Result] indicating success or failure.
+     */
+    override suspend operator fun invoke(
+        projectId: String,
+        roleId: String,
+        name: String?,
+        permissions: Map<RolePermission, Boolean>?,
+        isDefault: Boolean?
+    ): Result<Unit> {
+        // Fetch the current role details to get existing values if not provided
+        val currentRoleResult = projectRoleRepository.getRoleDetails(projectId, roleId)
+
+        if (currentRoleResult.isFailure) {
+            return Result.failure(currentRoleResult.exceptionOrNull() ?: Exception("Failed to fetch current role details."))
+        }
+
+        val currentRole = currentRoleResult.getOrNull()
+            ?: return Result.failure(Exception("Role with ID $roleId not found in project $projectId."))
+
+        // Use provided values or fallback to current role's values for name and permissions
+        val updatedName = name ?: currentRole.name
+        val updatedPermissions = permissions ?: currentRole.permissions
+
+        // The isDefault parameter can be passed directly to the repository as it handles nullable.
+        // If name or permissions were null, we use the currentRole's values.
+        return projectRoleRepository.updateRole(
+            projectId = projectId,
+            roleId = roleId,
+            name = updatedName,
+            permissions = updatedPermissions,
+            isDefault = isDefault // Pass isDefault as is, can be null for no change
+        )
+    }
+}

--- a/domain/src/test/java/com/example/domain/usecase/project/member/AddProjectMemberUseCaseImplTest.kt
+++ b/domain/src/test/java/com/example/domain/usecase/project/member/AddProjectMemberUseCaseImplTest.kt
@@ -1,0 +1,62 @@
+package com.example.domain.usecase.project.member
+
+import com.example.domain.repository.ProjectMemberRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.verify
+import org.mockito.MockitoAnnotations
+import kotlin.Result
+import org.junit.Assert.*
+
+@ExperimentalCoroutinesApi
+class AddProjectMemberUseCaseImplTest {
+
+    @Mock
+    private lateinit var projectMemberRepository: ProjectMemberRepository
+
+    private lateinit var addProjectMemberUseCase: AddProjectMemberUseCaseImpl
+
+    private val testProjectId = "project1"
+    private val testUserId = "user1"
+    private val testRoleIds = listOf("role1", "role2")
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        addProjectMemberUseCase = AddProjectMemberUseCaseImpl(projectMemberRepository)
+    }
+
+    @Test
+    fun `invoke success should call repository and return success`() = runTest {
+        // Arrange
+        `when`(projectMemberRepository.addMemberToProject(testProjectId, testUserId, testRoleIds))
+            .thenReturn(Result.success(Unit))
+
+        // Act
+        val result = addProjectMemberUseCase(testProjectId, testUserId, testRoleIds)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        verify(projectMemberRepository).addMemberToProject(testProjectId, testUserId, testRoleIds)
+    }
+
+    @Test
+    fun `invoke failure should call repository and return failure`() = runTest {
+        // Arrange
+        val exception = RuntimeException("Add member failed")
+        `when`(projectMemberRepository.addMemberToProject(testProjectId, testUserId, testRoleIds))
+            .thenReturn(Result.failure(exception))
+
+        // Act
+        val result = addProjectMemberUseCase(testProjectId, testUserId, testRoleIds)
+
+        // Assert
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+        verify(projectMemberRepository).addMemberToProject(testProjectId, testUserId, testRoleIds)
+    }
+}

--- a/domain/src/test/java/com/example/domain/usecase/project/member/GetMembersInRoleUseCaseImplTest.kt
+++ b/domain/src/test/java/com/example/domain/usecase/project/member/GetMembersInRoleUseCaseImplTest.kt
@@ -1,0 +1,85 @@
+package com.example.domain.usecase.project.member
+
+import com.example.domain.model.ProjectMember
+import com.example.domain.repository.ProjectMemberRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.verify
+import org.mockito.MockitoAnnotations
+import org.junit.Assert.*
+
+@ExperimentalCoroutinesApi
+class GetMembersInRoleUseCaseImplTest {
+
+    @Mock
+    private lateinit var projectMemberRepository: ProjectMemberRepository
+
+    private lateinit var getMembersInRoleUseCase: GetMembersInRoleUseCaseImpl
+
+    private val testProjectId = "project1"
+    private val testRoleId = "targetRole"
+
+    private val member1 = ProjectMember("user1", "Alice", null, listOf("targetRole", "otherRole"), 1000L)
+    private val member2 = ProjectMember("user2", "Bob", null, listOf("otherRole"), 2000L)
+    private val member3 = ProjectMember("user3", "Charlie", null, listOf("targetRole"), 500L)
+    private val member4 = ProjectMember("user4", "David", null, listOf(), 1500L)
+
+
+    private val allMembers = listOf(member1, member2, member3, member4)
+    private val membersInTargetRole = listOf(member1, member3)
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        getMembersInRoleUseCase = GetMembersInRoleUseCaseImpl(projectMemberRepository)
+    }
+
+    @Test
+    fun `invoke should return only members with the specified roleId`() = runTest {
+        // Arrange
+        `when`(projectMemberRepository.getProjectMembersStream(testProjectId)).thenReturn(flowOf(allMembers))
+
+        // Act
+        val result = getMembersInRoleUseCase(testProjectId, testRoleId).first()
+
+        // Assert
+        assertEquals(membersInTargetRole.size, result.size)
+        assertTrue(result.containsAll(membersInTargetRole))
+        assertFalse(result.contains(member2)) // Bob should not be there
+        assertFalse(result.contains(member4)) // David should not be there
+        verify(projectMemberRepository).getProjectMembersStream(testProjectId)
+    }
+
+    @Test
+    fun `invoke when no members have the roleId should return empty list`() = runTest {
+        // Arrange
+        val roleWithNoMembers = "nonExistentRole"
+        `when`(projectMemberRepository.getProjectMembersStream(testProjectId)).thenReturn(flowOf(allMembers))
+
+        // Act
+        val result = getMembersInRoleUseCase(testProjectId, roleWithNoMembers).first()
+
+        // Assert
+        assertTrue(result.isEmpty())
+        verify(projectMemberRepository).getProjectMembersStream(testProjectId)
+    }
+
+    @Test
+    fun `invoke when member list is empty should return empty list`() = runTest {
+        // Arrange
+        `when`(projectMemberRepository.getProjectMembersStream(testProjectId)).thenReturn(flowOf(emptyList()))
+
+        // Act
+        val result = getMembersInRoleUseCase(testProjectId, testRoleId).first()
+
+        // Assert
+        assertTrue(result.isEmpty())
+        verify(projectMemberRepository).getProjectMembersStream(testProjectId)
+    }
+}

--- a/domain/src/test/java/com/example/domain/usecase/project/member/GetProjectMemberUseCaseImplTest.kt
+++ b/domain/src/test/java/com/example/domain/usecase/project/member/GetProjectMemberUseCaseImplTest.kt
@@ -1,0 +1,85 @@
+package com.example.domain.usecase.project.member
+
+import com.example.domain.model.ProjectMember
+import com.example.domain.repository.ProjectMemberRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.verify
+import org.mockito.MockitoAnnotations
+import kotlin.Result
+import org.junit.Assert.*
+
+@ExperimentalCoroutinesApi
+class GetProjectMemberUseCaseImplTest {
+
+    @Mock
+    private lateinit var projectMemberRepository: ProjectMemberRepository
+
+    private lateinit var getProjectMemberUseCase: GetProjectMemberUseCaseImpl
+
+    private val testProjectId = "project1"
+    private val testUserId = "user1"
+    private val testMember = ProjectMember(
+        userId = testUserId,
+        userName = "Test User",
+        profileImageUrl = null,
+        roleIds = listOf("role1"),
+        joinedAt = System.currentTimeMillis()
+    )
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        getProjectMemberUseCase = GetProjectMemberUseCaseImpl(projectMemberRepository)
+    }
+
+    @Test
+    fun `invoke success should call repository and return member`() = runTest {
+        // Arrange
+        `when`(projectMemberRepository.getProjectMember(testProjectId, testUserId))
+            .thenReturn(Result.success(testMember))
+
+        // Act
+        val result = getProjectMemberUseCase(testProjectId, testUserId)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        assertEquals(testMember, result.getOrNull())
+        verify(projectMemberRepository).getProjectMember(testProjectId, testUserId)
+    }
+
+    @Test
+    fun `invoke member not found should call repository and return success with null`() = runTest {
+        // Arrange
+        `when`(projectMemberRepository.getProjectMember(testProjectId, testUserId))
+            .thenReturn(Result.success(null))
+
+        // Act
+        val result = getProjectMemberUseCase(testProjectId, testUserId)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        assertNull(result.getOrNull())
+        verify(projectMemberRepository).getProjectMember(testProjectId, testUserId)
+    }
+
+    @Test
+    fun `invoke failure should call repository and return failure`() = runTest {
+        // Arrange
+        val exception = RuntimeException("Get member failed")
+        `when`(projectMemberRepository.getProjectMember(testProjectId, testUserId))
+            .thenReturn(Result.failure(exception))
+
+        // Act
+        val result = getProjectMemberUseCase(testProjectId, testUserId)
+
+        // Assert
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+        verify(projectMemberRepository).getProjectMember(testProjectId, testUserId)
+    }
+}

--- a/domain/src/test/java/com/example/domain/usecase/project/member/GetProjectMembersUseCaseImplTest.kt
+++ b/domain/src/test/java/com/example/domain/usecase/project/member/GetProjectMembersUseCaseImplTest.kt
@@ -1,0 +1,114 @@
+package com.example.domain.usecase.project.member
+
+import com.example.domain.model.ProjectMember
+import com.example.domain.model.project.MemberSortOption
+import com.example.domain.repository.ProjectMemberRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.verify
+import org.mockito.MockitoAnnotations
+import org.junit.Assert.*
+
+@ExperimentalCoroutinesApi
+class GetProjectMembersUseCaseImplTest {
+
+    @Mock
+    private lateinit var projectMemberRepository: ProjectMemberRepository
+
+    private lateinit var getProjectMembersUseCase: GetProjectMembersUseCaseImpl
+
+    private val testProjectId = "project1"
+
+    private val member1 = ProjectMember("user1", "Alice", null, listOf("role1", "role2"), 1000L)
+    private val member2 = ProjectMember("user2", "Bob", null, listOf("role2"), 2000L)
+    private val member3 = ProjectMember("user3", "charlie", null, listOf("role1"), 500L) // Lowercase for sorting test
+    private val member4 = ProjectMember("user4", "David", null, listOf("role3"), 1500L)
+
+    private val allMembers = listOf(member1, member2, member3, member4)
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        getProjectMembersUseCase = GetProjectMembersUseCaseImpl(projectMemberRepository)
+        `when`(projectMemberRepository.getProjectMembersStream(testProjectId)).thenReturn(flowOf(allMembers))
+    }
+
+    @Test
+    fun `invoke with no filter and no sort should return all members`() = runTest {
+        // Act
+        val result = getProjectMembersUseCase(testProjectId, null, null).first()
+
+        // Assert
+        assertEquals(allMembers.size, result.size)
+        assertTrue(result.containsAll(allMembers))
+        verify(projectMemberRepository).getProjectMembersStream(testProjectId)
+    }
+
+    @Test
+    fun `invoke with roleIdFilter should return filtered members`() = runTest {
+        val roleIdToFilter = "role1"
+        // Act
+        val result = getProjectMembersUseCase(testProjectId, roleIdToFilter, null).first()
+
+        // Assert
+        assertEquals(2, result.size)
+        assertTrue(result.all { it.roleIds.contains(roleIdToFilter) })
+        assertTrue(result.contains(member1))
+        assertTrue(result.contains(member3))
+    }
+
+    @Test
+    fun `invoke with sortBy NAME_ASC should return members sorted by name ascending`() = runTest {
+        // Act
+        val result = getProjectMembersUseCase(testProjectId, null, MemberSortOption.NAME_ASC).first()
+
+        // Assert
+        assertEquals(listOf(member1, member2, member3, member4).sortedBy { it.userName.lowercase() }, result)
+    }
+
+    @Test
+    fun `invoke with sortBy NAME_DESC should return members sorted by name descending`() = runTest {
+        // Act
+        val result = getProjectMembersUseCase(testProjectId, null, MemberSortOption.NAME_DESC).first()
+
+        // Assert
+        assertEquals(listOf(member1, member2, member3, member4).sortedByDescending { it.userName.lowercase() }, result)
+    }
+    
+    @Test
+    fun `invoke with sortBy JOINED_AT_ASC should return members sorted by joinedAt ascending`() = runTest {
+        // Act
+        val result = getProjectMembersUseCase(testProjectId, null, MemberSortOption.JOINED_AT_ASC).first()
+
+        // Assert
+        assertEquals(allMembers.sortedBy { it.joinedAt }, result)
+    }
+
+    @Test
+    fun `invoke with sortBy JOINED_AT_DESC should return members sorted by joinedAt descending`() = runTest {
+        // Act
+        val result = getProjectMembersUseCase(testProjectId, null, MemberSortOption.JOINED_AT_DESC).first()
+
+        // Assert
+        assertEquals(allMembers.sortedByDescending { it.joinedAt }, result)
+    }
+    
+    @Test
+    fun `invoke with roleIdFilter and sortBy NAME_ASC should return filtered and sorted members`() = runTest {
+        val roleIdToFilter = "role2"
+        // Expected: member1 (Alice), member2 (Bob) -> sorted: member1, member2
+        val expectedMembers = listOf(member1, member2).sortedBy { it.userName.lowercase() }
+        
+        // Act
+        val result = getProjectMembersUseCase(testProjectId, roleIdToFilter, MemberSortOption.NAME_ASC).first()
+
+        // Assert
+        assertEquals(expectedMembers, result)
+    }
+}

--- a/domain/src/test/java/com/example/domain/usecase/project/member/RemoveProjectMemberUseCaseImplTest.kt
+++ b/domain/src/test/java/com/example/domain/usecase/project/member/RemoveProjectMemberUseCaseImplTest.kt
@@ -1,0 +1,61 @@
+package com.example.domain.usecase.project.member
+
+import com.example.domain.repository.ProjectMemberRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.verify
+import org.mockito.MockitoAnnotations
+import kotlin.Result
+import org.junit.Assert.*
+
+@ExperimentalCoroutinesApi
+class RemoveProjectMemberUseCaseImplTest {
+
+    @Mock
+    private lateinit var projectMemberRepository: ProjectMemberRepository
+
+    private lateinit var removeProjectMemberUseCase: RemoveProjectMemberUseCaseImpl
+
+    private val testProjectId = "project1"
+    private val testUserId = "user1"
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        removeProjectMemberUseCase = RemoveProjectMemberUseCaseImpl(projectMemberRepository)
+    }
+
+    @Test
+    fun `invoke success should call repository and return success`() = runTest {
+        // Arrange
+        `when`(projectMemberRepository.removeMemberFromProject(testProjectId, testUserId))
+            .thenReturn(Result.success(Unit))
+
+        // Act
+        val result = removeProjectMemberUseCase(testProjectId, testUserId)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        verify(projectMemberRepository).removeMemberFromProject(testProjectId, testUserId)
+    }
+
+    @Test
+    fun `invoke failure should call repository and return failure`() = runTest {
+        // Arrange
+        val exception = RuntimeException("Remove member failed")
+        `when`(projectMemberRepository.removeMemberFromProject(testProjectId, testUserId))
+            .thenReturn(Result.failure(exception))
+
+        // Act
+        val result = removeProjectMemberUseCase(testProjectId, testUserId)
+
+        // Assert
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+        verify(projectMemberRepository).removeMemberFromProject(testProjectId, testUserId)
+    }
+}

--- a/domain/src/test/java/com/example/domain/usecase/project/member/UpdateProjectMemberUseCaseImplTest.kt
+++ b/domain/src/test/java/com/example/domain/usecase/project/member/UpdateProjectMemberUseCaseImplTest.kt
@@ -1,0 +1,199 @@
+package com.example.domain.usecase.project.member
+
+import com.example.domain.repository.ProjectMemberRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.*
+import org.mockito.MockitoAnnotations
+import kotlin.Result
+import org.junit.Assert.*
+
+@ExperimentalCoroutinesApi
+class UpdateProjectMemberUseCaseImplTest {
+
+    @Mock
+    private lateinit var projectMemberRepository: ProjectMemberRepository
+
+    private lateinit var updateProjectMemberUseCase: UpdateProjectMemberUseCaseImpl
+
+    private val testProjectId = "project1"
+    private val testUserId = "user1"
+    private val testRoleIds = listOf("roleNew1", "roleNew2")
+    private val testChannelsToAdd = listOf("channelAdd1", "channelAdd2")
+    private val testChannelsToRemove = listOf("channelRemove1")
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        updateProjectMemberUseCase = UpdateProjectMemberUseCaseImpl(projectMemberRepository)
+    }
+
+    @Test
+    fun `invoke with all parameters null should succeed without calling repository methods`() = runTest {
+        // Act
+        val result = updateProjectMemberUseCase(testProjectId, testUserId, null, null, null)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        verifyNoInteractions(projectMemberRepository)
+    }
+
+    @Test
+    fun `invoke with only roleIds should call updateMemberRoles and succeed`() = runTest {
+        // Arrange
+        `when`(projectMemberRepository.updateMemberRoles(testProjectId, testUserId, testRoleIds))
+            .thenReturn(Result.success(Unit))
+
+        // Act
+        val result = updateProjectMemberUseCase(testProjectId, testUserId, testRoleIds, null, null)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        verify(projectMemberRepository).updateMemberRoles(testProjectId, testUserId, testRoleIds)
+        verify(projectMemberRepository, never()).addChannelAccessToMember(anyString(), anyString(), anyString())
+        verify(projectMemberRepository, never()).removeChannelAccessFromMember(anyString(), anyString(), anyString())
+    }
+
+    @Test
+    fun `invoke with only channelIdsToAdd should call addChannelAccessToMember and succeed`() = runTest {
+        // Arrange
+        testChannelsToAdd.forEach { channelId ->
+            `when`(projectMemberRepository.addChannelAccessToMember(testProjectId, testUserId, channelId))
+                .thenReturn(Result.success(Unit))
+        }
+
+        // Act
+        val result = updateProjectMemberUseCase(testProjectId, testUserId, null, testChannelsToAdd, null)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        verify(projectMemberRepository, never()).updateMemberRoles(anyString(), anyString(), anyList())
+        testChannelsToAdd.forEach { channelId ->
+            verify(projectMemberRepository).addChannelAccessToMember(testProjectId, testUserId, channelId)
+        }
+        verify(projectMemberRepository, never()).removeChannelAccessFromMember(anyString(), anyString(), anyString())
+    }
+
+    @Test
+    fun `invoke with only channelIdsToRemove should call removeChannelAccessFromMember and succeed`() = runTest {
+        // Arrange
+        testChannelsToRemove.forEach { channelId ->
+            `when`(projectMemberRepository.removeChannelAccessFromMember(testProjectId, testUserId, channelId))
+                .thenReturn(Result.success(Unit))
+        }
+
+        // Act
+        val result = updateProjectMemberUseCase(testProjectId, testUserId, null, null, testChannelsToRemove)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        verify(projectMemberRepository, never()).updateMemberRoles(anyString(), anyString(), anyList())
+        verify(projectMemberRepository, never()).addChannelAccessToMember(anyString(), anyString(), anyString())
+        testChannelsToRemove.forEach { channelId ->
+            verify(projectMemberRepository).removeChannelAccessFromMember(testProjectId, testUserId, channelId)
+        }
+    }
+
+    @Test
+    fun `invoke with all parameters should call all relevant repository methods and succeed`() = runTest {
+        // Arrange
+        `when`(projectMemberRepository.updateMemberRoles(testProjectId, testUserId, testRoleIds))
+            .thenReturn(Result.success(Unit))
+        testChannelsToAdd.forEach { channelId ->
+            `when`(projectMemberRepository.addChannelAccessToMember(testProjectId, testUserId, channelId))
+                .thenReturn(Result.success(Unit))
+        }
+        testChannelsToRemove.forEach { channelId ->
+            `when`(projectMemberRepository.removeChannelAccessFromMember(testProjectId, testUserId, channelId))
+                .thenReturn(Result.success(Unit))
+        }
+
+        // Act
+        val result = updateProjectMemberUseCase(testProjectId, testUserId, testRoleIds, testChannelsToAdd, testChannelsToRemove)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        verify(projectMemberRepository).updateMemberRoles(testProjectId, testUserId, testRoleIds)
+        testChannelsToAdd.forEach { channelId ->
+            verify(projectMemberRepository).addChannelAccessToMember(testProjectId, testUserId, channelId)
+        }
+        testChannelsToRemove.forEach { channelId ->
+            verify(projectMemberRepository).removeChannelAccessFromMember(testProjectId, testUserId, channelId)
+        }
+    }
+
+    @Test
+    fun `invoke updateMemberRoles fails should return failure and not call other methods`() = runTest {
+        // Arrange
+        val exception = RuntimeException("Roles update failed")
+        `when`(projectMemberRepository.updateMemberRoles(testProjectId, testUserId, testRoleIds))
+            .thenReturn(Result.failure(exception))
+
+        // Act
+        val result = updateProjectMemberUseCase(testProjectId, testUserId, testRoleIds, testChannelsToAdd, testChannelsToRemove)
+
+        // Assert
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+        verify(projectMemberRepository).updateMemberRoles(testProjectId, testUserId, testRoleIds)
+        verify(projectMemberRepository, never()).addChannelAccessToMember(anyString(), anyString(), anyString())
+        verify(projectMemberRepository, never()).removeChannelAccessFromMember(anyString(), anyString(), anyString())
+    }
+
+    @Test
+    fun `invoke addChannelAccessToMember fails should return failure and not call subsequent methods`() = runTest {
+        // Arrange
+        val exception = RuntimeException("Add channel access failed")
+        `when`(projectMemberRepository.updateMemberRoles(testProjectId, testUserId, testRoleIds))
+            .thenReturn(Result.success(Unit)) // Roles update succeeds
+        `when`(projectMemberRepository.addChannelAccessToMember(testProjectId, testUserId, testChannelsToAdd[0]))
+            .thenReturn(Result.failure(exception)) // First add fails
+
+        // Act
+        val result = updateProjectMemberUseCase(testProjectId, testUserId, testRoleIds, testChannelsToAdd, testChannelsToRemove)
+
+        // Assert
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+        verify(projectMemberRepository).updateMemberRoles(testProjectId, testUserId, testRoleIds)
+        verify(projectMemberRepository).addChannelAccessToMember(testProjectId, testUserId, testChannelsToAdd[0])
+        // Ensure subsequent add calls and remove calls are not made
+        if (testChannelsToAdd.size > 1) {
+            verify(projectMemberRepository, never()).addChannelAccessToMember(testProjectId, testUserId, testChannelsToAdd[1])
+        }
+        verify(projectMemberRepository, never()).removeChannelAccessFromMember(anyString(), anyString(), anyString())
+    }
+
+    @Test
+    fun `invoke removeChannelAccessFromMember fails should return failure`() = runTest {
+        // Arrange
+        val exception = RuntimeException("Remove channel access failed")
+        `when`(projectMemberRepository.updateMemberRoles(testProjectId, testUserId, testRoleIds))
+            .thenReturn(Result.success(Unit))
+        testChannelsToAdd.forEach { channelId ->
+            `when`(projectMemberRepository.addChannelAccessToMember(testProjectId, testUserId, channelId))
+                .thenReturn(Result.success(Unit))
+        }
+        `when`(projectMemberRepository.removeChannelAccessFromMember(testProjectId, testUserId, testChannelsToRemove[0]))
+            .thenReturn(Result.failure(exception)) // First remove fails
+
+        // Act
+        val result = updateProjectMemberUseCase(testProjectId, testUserId, testRoleIds, testChannelsToAdd, testChannelsToRemove)
+
+        // Assert
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+        verify(projectMemberRepository).updateMemberRoles(testProjectId, testUserId, testRoleIds)
+        testChannelsToAdd.forEach { channelId ->
+            verify(projectMemberRepository).addChannelAccessToMember(testProjectId, testUserId, channelId)
+        }
+        verify(projectMemberRepository).removeChannelAccessFromMember(testProjectId, testUserId, testChannelsToRemove[0])
+        // Ensure subsequent remove calls are not made
+        if (testChannelsToRemove.size > 1) {
+             verify(projectMemberRepository, never()).removeChannelAccessFromMember(testProjectId, testUserId, testChannelsToRemove[1])
+        }
+    }
+}

--- a/domain/src/test/java/com/example/domain/usecase/project/role/CreateProjectRoleUseCaseImplTest.kt
+++ b/domain/src/test/java/com/example/domain/usecase/project/role/CreateProjectRoleUseCaseImplTest.kt
@@ -1,0 +1,82 @@
+package com.example.domain.usecase.project.role
+
+import com.example.domain.model.RolePermission
+import com.example.domain.repository.ProjectRoleRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.verify
+import org.mockito.MockitoAnnotations
+import kotlin.Result
+import org.junit.Assert.*
+
+@ExperimentalCoroutinesApi
+class CreateProjectRoleUseCaseImplTest {
+
+    @Mock
+    private lateinit var projectRoleRepository: ProjectRoleRepository
+
+    private lateinit var createProjectRoleUseCase: CreateProjectRoleUseCaseImpl
+
+    private val testProjectId = "project1"
+    private val testRoleName = "New Role"
+    private val testPermissions = mapOf(RolePermission.MANAGE_TASKS to true)
+    private val testIsDefault = false
+    private val expectedRoleId = "newRoleId"
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        createProjectRoleUseCase = CreateProjectRoleUseCaseImpl(projectRoleRepository)
+    }
+
+    @Test
+    fun `invoke success should call repository and return role ID`() = runTest {
+        // Arrange
+        `when`(projectRoleRepository.createRole(testProjectId, testRoleName, testPermissions, testIsDefault))
+            .thenReturn(Result.success(expectedRoleId))
+
+        // Act
+        val result = createProjectRoleUseCase(testProjectId, testRoleName, testPermissions, testIsDefault)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        assertEquals(expectedRoleId, result.getOrNull())
+        verify(projectRoleRepository).createRole(testProjectId, testRoleName, testPermissions, testIsDefault)
+    }
+
+    @Test
+    fun `invoke failure should call repository and return failure`() = runTest {
+        // Arrange
+        val exception = RuntimeException("Create role failed")
+        `when`(projectRoleRepository.createRole(testProjectId, testRoleName, testPermissions, testIsDefault))
+            .thenReturn(Result.failure(exception))
+
+        // Act
+        val result = createProjectRoleUseCase(testProjectId, testRoleName, testPermissions, testIsDefault)
+
+        // Assert
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+        verify(projectRoleRepository).createRole(testProjectId, testRoleName, testPermissions, testIsDefault)
+    }
+
+    @Test
+    fun `invoke with isDefault true should call repository with isDefault true`() = runTest {
+        // Arrange
+        val isDefaultTrue = true
+        `when`(projectRoleRepository.createRole(testProjectId, testRoleName, testPermissions, isDefaultTrue))
+            .thenReturn(Result.success(expectedRoleId))
+
+        // Act
+        val result = createProjectRoleUseCase(testProjectId, testRoleName, testPermissions, isDefaultTrue)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        assertEquals(expectedRoleId, result.getOrNull())
+        verify(projectRoleRepository).createRole(testProjectId, testRoleName, testPermissions, isDefaultTrue)
+    }
+}

--- a/domain/src/test/java/com/example/domain/usecase/project/role/DeleteProjectRoleUseCaseImplTest.kt
+++ b/domain/src/test/java/com/example/domain/usecase/project/role/DeleteProjectRoleUseCaseImplTest.kt
@@ -1,0 +1,61 @@
+package com.example.domain.usecase.project.role
+
+import com.example.domain.repository.ProjectRoleRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.verify
+import org.mockito.MockitoAnnotations
+import kotlin.Result
+import org.junit.Assert.*
+
+@ExperimentalCoroutinesApi
+class DeleteProjectRoleUseCaseImplTest {
+
+    @Mock
+    private lateinit var projectRoleRepository: ProjectRoleRepository
+
+    private lateinit var deleteProjectRoleUseCase: DeleteProjectRoleUseCaseImpl
+
+    private val testProjectId = "project1"
+    private val testRoleId = "role1"
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        deleteProjectRoleUseCase = DeleteProjectRoleUseCaseImpl(projectRoleRepository)
+    }
+
+    @Test
+    fun `invoke success should call repository and return success`() = runTest {
+        // Arrange
+        `when`(projectRoleRepository.deleteRole(testProjectId, testRoleId))
+            .thenReturn(Result.success(Unit))
+
+        // Act
+        val result = deleteProjectRoleUseCase(testProjectId, testRoleId)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        verify(projectRoleRepository).deleteRole(testProjectId, testRoleId)
+    }
+
+    @Test
+    fun `invoke failure should call repository and return failure`() = runTest {
+        // Arrange
+        val exception = RuntimeException("Delete role failed")
+        `when`(projectRoleRepository.deleteRole(testProjectId, testRoleId))
+            .thenReturn(Result.failure(exception))
+
+        // Act
+        val result = deleteProjectRoleUseCase(testProjectId, testRoleId)
+
+        // Assert
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+        verify(projectRoleRepository).deleteRole(testProjectId, testRoleId)
+    }
+}

--- a/domain/src/test/java/com/example/domain/usecase/project/role/GetProjectRoleUseCaseImplTest.kt
+++ b/domain/src/test/java/com/example/domain/usecase/project/role/GetProjectRoleUseCaseImplTest.kt
@@ -1,0 +1,87 @@
+package com.example.domain.usecase.project.role
+
+import com.example.domain.model.Role
+import com.example.domain.model.RolePermission
+import com.example.domain.repository.ProjectRoleRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.verify
+import org.mockito.MockitoAnnotations
+import kotlin.Result
+import org.junit.Assert.*
+
+@ExperimentalCoroutinesApi
+class GetProjectRoleUseCaseImplTest {
+
+    @Mock
+    private lateinit var projectRoleRepository: ProjectRoleRepository
+
+    private lateinit var getProjectRoleUseCase: GetProjectRoleUseCaseImpl
+
+    private val testProjectId = "project1"
+    private val testRoleId = "role1"
+    private val testRole = Role(
+        id = testRoleId,
+        projectId = testProjectId,
+        name = "Test Role",
+        permissions = mapOf(RolePermission.MANAGE_MEMBERS to true),
+        isDefault = false,
+        memberCount = 5
+    )
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        getProjectRoleUseCase = GetProjectRoleUseCaseImpl(projectRoleRepository)
+    }
+
+    @Test
+    fun `invoke success should call repository and return role`() = runTest {
+        // Arrange
+        `when`(projectRoleRepository.getRoleDetails(testProjectId, testRoleId))
+            .thenReturn(Result.success(testRole))
+
+        // Act
+        val result = getProjectRoleUseCase(testProjectId, testRoleId)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        assertEquals(testRole, result.getOrNull())
+        verify(projectRoleRepository).getRoleDetails(testProjectId, testRoleId)
+    }
+
+    @Test
+    fun `invoke role not found should call repository and return success with null`() = runTest {
+        // Arrange
+        `when`(projectRoleRepository.getRoleDetails(testProjectId, testRoleId))
+            .thenReturn(Result.success(null))
+
+        // Act
+        val result = getProjectRoleUseCase(testProjectId, testRoleId)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        assertNull(result.getOrNull())
+        verify(projectRoleRepository).getRoleDetails(testProjectId, testRoleId)
+    }
+
+    @Test
+    fun `invoke failure should call repository and return failure`() = runTest {
+        // Arrange
+        val exception = RuntimeException("Get role failed")
+        `when`(projectRoleRepository.getRoleDetails(testProjectId, testRoleId))
+            .thenReturn(Result.failure(exception))
+
+        // Act
+        val result = getProjectRoleUseCase(testProjectId, testRoleId)
+
+        // Assert
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+        verify(projectRoleRepository).getRoleDetails(testProjectId, testRoleId)
+    }
+}

--- a/domain/src/test/java/com/example/domain/usecase/project/role/GetProjectRolesUseCaseImplTest.kt
+++ b/domain/src/test/java/com/example/domain/usecase/project/role/GetProjectRolesUseCaseImplTest.kt
@@ -1,0 +1,104 @@
+package com.example.domain.usecase.project.role
+
+import com.example.domain.model.Role
+import com.example.domain.model.RolePermission
+import com.example.domain.model.project.RoleSortOption
+import com.example.domain.repository.ProjectRoleRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.verify
+import org.mockito.MockitoAnnotations
+import org.junit.Assert.*
+
+@ExperimentalCoroutinesApi
+class GetProjectRolesUseCaseImplTest {
+
+    @Mock
+    private lateinit var projectRoleRepository: ProjectRoleRepository
+
+    private lateinit var getProjectRolesUseCase: GetProjectRolesUseCaseImpl
+
+    private val testProjectId = "project1"
+
+    private val role1 = Role("role1", testProjectId, "Alpha Role", mapOf(RolePermission.MANAGE_MEMBERS to true), false, 3)
+    private val role2 = Role("role2", testProjectId, "Beta Role", mapOf(RolePermission.MANAGE_TASKS to true), true, 5)
+    private val role3 = Role("role3", testProjectId, "gamma Role", mapOf(RolePermission.VIEW_PROJECT to true), false, 1) // Lowercase for sorting
+    private val role4 = Role("role4", testProjectId, "Delta Role", mapOf(), true, 10)
+
+
+    private val allRoles = listOf(role1, role2, role3, role4)
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        getProjectRolesUseCase = GetProjectRolesUseCaseImpl(projectRoleRepository)
+        `when`(projectRoleRepository.getRolesStream(testProjectId)).thenReturn(flowOf(allRoles))
+    }
+
+    @Test
+    fun `invoke with no filter and no sort should return all roles`() = runTest {
+        // Act
+        val result = getProjectRolesUseCase(testProjectId, null, null).first()
+
+        // Assert
+        assertEquals(allRoles.size, result.size)
+        assertTrue(result.containsAll(allRoles))
+        verify(projectRoleRepository).getRolesStream(testProjectId)
+    }
+
+    @Test
+    fun `invoke with filterIsDefault true should return only default roles`() = runTest {
+        // Act
+        val result = getProjectRolesUseCase(testProjectId, true, null).first()
+        val expectedRoles = allRoles.filter { it.isDefault }
+
+        // Assert
+        assertEquals(expectedRoles.size, result.size)
+        assertTrue(result.containsAll(expectedRoles))
+    }
+
+    @Test
+    fun `invoke with filterIsDefault false should return only non-default roles`() = runTest {
+        // Act
+        val result = getProjectRolesUseCase(testProjectId, false, null).first()
+        val expectedRoles = allRoles.filter { !it.isDefault }
+
+        // Assert
+        assertEquals(expectedRoles.size, result.size)
+        assertTrue(result.containsAll(expectedRoles))
+    }
+
+    @Test
+    fun `invoke with sortBy NAME_ASC should return roles sorted by name ascending`() = runTest {
+        // Act
+        val result = getProjectRolesUseCase(testProjectId, null, RoleSortOption.NAME_ASC).first()
+
+        // Assert
+        assertEquals(allRoles.sortedBy { it.name.lowercase() }, result)
+    }
+
+    @Test
+    fun `invoke with sortBy NAME_DESC should return roles sorted by name descending`() = runTest {
+        // Act
+        val result = getProjectRolesUseCase(testProjectId, null, RoleSortOption.NAME_DESC).first()
+
+        // Assert
+        assertEquals(allRoles.sortedByDescending { it.name.lowercase() }, result)
+    }
+    
+    @Test
+    fun `invoke with filterIsDefault true and sortBy NAME_ASC should return filtered and sorted roles`() = runTest {
+        // Act
+        val result = getProjectRolesUseCase(testProjectId, true, RoleSortOption.NAME_ASC).first()
+        val expectedRoles = allRoles.filter { it.isDefault }.sortedBy { it.name.lowercase() }
+
+        // Assert
+        assertEquals(expectedRoles, result)
+    }
+}

--- a/domain/src/test/java/com/example/domain/usecase/project/role/UpdateProjectRoleUseCaseImplTest.kt
+++ b/domain/src/test/java/com/example/domain/usecase/project/role/UpdateProjectRoleUseCaseImplTest.kt
@@ -1,0 +1,185 @@
+package com.example.domain.usecase.project.role
+
+import com.example.domain.model.Role
+import com.example.domain.model.RolePermission
+import com.example.domain.repository.ProjectRoleRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.*
+import org.mockito.MockitoAnnotations
+import kotlin.Result
+import org.junit.Assert.*
+
+@ExperimentalCoroutinesApi
+class UpdateProjectRoleUseCaseImplTest {
+
+    @Mock
+    private lateinit var projectRoleRepository: ProjectRoleRepository
+
+    private lateinit var updateProjectRoleUseCase: UpdateProjectRoleUseCaseImpl
+
+    private val testProjectId = "project1"
+    private val testRoleId = "role1"
+
+    private val originalRole = Role(
+        id = testRoleId,
+        projectId = testProjectId,
+        name = "Original Name",
+        permissions = mapOf(RolePermission.MANAGE_MEMBERS to true),
+        isDefault = false,
+        memberCount = 1
+    )
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        updateProjectRoleUseCase = UpdateProjectRoleUseCaseImpl(projectRoleRepository)
+    }
+
+    @Test
+    fun `invoke with all parameters null should fetch role and update with original values for name and permissions`() = runTest {
+        // Arrange
+        `when`(projectRoleRepository.getRoleDetails(testProjectId, testRoleId))
+            .thenReturn(Result.success(originalRole))
+        `when`(projectRoleRepository.updateRole(testProjectId, testRoleId, originalRole.name, originalRole.permissions, null))
+            .thenReturn(Result.success(Unit))
+
+        // Act
+        val result = updateProjectRoleUseCase(testProjectId, testRoleId, null, null, null)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        verify(projectRoleRepository).getRoleDetails(testProjectId, testRoleId)
+        verify(projectRoleRepository).updateRole(testProjectId, testRoleId, originalRole.name, originalRole.permissions, null)
+    }
+
+    @Test
+    fun `invoke with new name should fetch role and update only name`() = runTest {
+        // Arrange
+        val newName = "New Role Name"
+        `when`(projectRoleRepository.getRoleDetails(testProjectId, testRoleId))
+            .thenReturn(Result.success(originalRole))
+        `when`(projectRoleRepository.updateRole(testProjectId, testRoleId, newName, originalRole.permissions, null))
+            .thenReturn(Result.success(Unit))
+
+        // Act
+        val result = updateProjectRoleUseCase(testProjectId, testRoleId, newName, null, null)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        verify(projectRoleRepository).getRoleDetails(testProjectId, testRoleId)
+        verify(projectRoleRepository).updateRole(testProjectId, testRoleId, newName, originalRole.permissions, null)
+    }
+
+    @Test
+    fun `invoke with new permissions should fetch role and update only permissions`() = runTest {
+        // Arrange
+        val newPermissions = mapOf(RolePermission.MANAGE_TASKS to true)
+        `when`(projectRoleRepository.getRoleDetails(testProjectId, testRoleId))
+            .thenReturn(Result.success(originalRole))
+        `when`(projectRoleRepository.updateRole(testProjectId, testRoleId, originalRole.name, newPermissions, null))
+            .thenReturn(Result.success(Unit))
+
+        // Act
+        val result = updateProjectRoleUseCase(testProjectId, testRoleId, null, newPermissions, null)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        verify(projectRoleRepository).getRoleDetails(testProjectId, testRoleId)
+        verify(projectRoleRepository).updateRole(testProjectId, testRoleId, originalRole.name, newPermissions, null)
+    }
+
+    @Test
+    fun `invoke with new isDefault should fetch role and update only isDefault`() = runTest {
+        // Arrange
+        val newIsDefault = true
+        `when`(projectRoleRepository.getRoleDetails(testProjectId, testRoleId))
+            .thenReturn(Result.success(originalRole))
+        `when`(projectRoleRepository.updateRole(testProjectId, testRoleId, originalRole.name, originalRole.permissions, newIsDefault))
+            .thenReturn(Result.success(Unit))
+
+        // Act
+        val result = updateProjectRoleUseCase(testProjectId, testRoleId, null, null, newIsDefault)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        verify(projectRoleRepository).getRoleDetails(testProjectId, testRoleId)
+        verify(projectRoleRepository).updateRole(testProjectId, testRoleId, originalRole.name, originalRole.permissions, newIsDefault)
+    }
+
+    @Test
+    fun `invoke with all new values should fetch role and update all values`() = runTest {
+        // Arrange
+        val newName = "Completely New Name"
+        val newPermissions = mapOf(RolePermission.VIEW_PROJECT to true, RolePermission.MANAGE_ROLES to false)
+        val newIsDefault = true
+        `when`(projectRoleRepository.getRoleDetails(testProjectId, testRoleId))
+            .thenReturn(Result.success(originalRole)) // Still need to mock this for the initial fetch
+        `when`(projectRoleRepository.updateRole(testProjectId, testRoleId, newName, newPermissions, newIsDefault))
+            .thenReturn(Result.success(Unit))
+
+        // Act
+        val result = updateProjectRoleUseCase(testProjectId, testRoleId, newName, newPermissions, newIsDefault)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        verify(projectRoleRepository).getRoleDetails(testProjectId, testRoleId) // Verifies it was called
+        verify(projectRoleRepository).updateRole(testProjectId, testRoleId, newName, newPermissions, newIsDefault)
+    }
+    
+    @Test
+    fun `invoke when getRoleDetails fails should return failure`() = runTest {
+        // Arrange
+        val exception = RuntimeException("Fetch role failed")
+        `when`(projectRoleRepository.getRoleDetails(testProjectId, testRoleId))
+            .thenReturn(Result.failure(exception))
+
+        // Act
+        val result = updateProjectRoleUseCase(testProjectId, testRoleId, "New Name", null, null)
+
+        // Assert
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+        verify(projectRoleRepository).getRoleDetails(testProjectId, testRoleId)
+        verify(projectRoleRepository, never()).updateRole(anyString(), anyString(), anyString(), anyMap(), anyBoolean())
+    }
+
+    @Test
+    fun `invoke when getRoleDetails returns null (role not found) should return failure`() = runTest {
+        // Arrange
+        `when`(projectRoleRepository.getRoleDetails(testProjectId, testRoleId))
+            .thenReturn(Result.success(null))
+
+        // Act
+        val result = updateProjectRoleUseCase(testProjectId, testRoleId, "New Name", null, null)
+
+        // Assert
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull()?.message?.contains("Role with ID $testRoleId not found") ?: false)
+        verify(projectRoleRepository).getRoleDetails(testProjectId, testRoleId)
+        verify(projectRoleRepository, never()).updateRole(anyString(), anyString(), anyString(), anyMap(), anyBoolean())
+    }
+    
+    @Test
+    fun `invoke when updateRole fails should return failure`() = runTest {
+        // Arrange
+        val newName = "New Name"
+        val exception = RuntimeException("Update role failed")
+        `when`(projectRoleRepository.getRoleDetails(testProjectId, testRoleId))
+            .thenReturn(Result.success(originalRole))
+        `when`(projectRoleRepository.updateRole(testProjectId, testRoleId, newName, originalRole.permissions, null))
+            .thenReturn(Result.failure(exception))
+
+        // Act
+        val result = updateProjectRoleUseCase(testProjectId, testRoleId, newName, null, null)
+
+        // Assert
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+        verify(projectRoleRepository).getRoleDetails(testProjectId, testRoleId)
+        verify(projectRoleRepository).updateRole(testProjectId, testRoleId, newName, originalRole.permissions, null)
+    }
+}


### PR DESCRIPTION
This commit introduces comprehensive CRUD (Create, Read, Update, Delete) UseCases for managing your project members and roles, adhering to the existing Clean Architecture pattern (data -> datasource -> repository -> usecase).

Key changes include:

1.  **Domain Models Updated**:
    *   `ProjectMember.kt`: Added `joinedAt: Long`.
    *   `Role.kt`: Added `isDefault: Boolean`.

2.  **Data Layer Enhancements**:
    *   `ProjectMemberRemoteDataSourceImpl`:
        *   Ensures `joinedAt` is set on member creation and mapped on read.
        *   Updates `projects/{projectId}/memberIds` array when members are added/removed to maintain data consistency.
    *   `ProjectRoleRemoteDataSourceImpl`:
        *   Handles `isDefault` field during role creation, update, and read.
        *   Refactored methods (`getRoleDetails`, `updateRole`, `deleteRole`) to use separate `projectId` and `roleId` parameters, removing composite ID logic.
    *   `ProjectRoleRemoteDataSource` interface updated accordingly.
    *   Added `getProjectMember` to `ProjectMemberRemoteDataSource` for direct member fetching.

3.  **Repository Layer Refinements**:
    *   `ProjectMemberRepositoryImpl`:
        *   `getProjectMember` now uses the direct fetch method from its remote data source.
    *   `ProjectRoleRepository` and `Impl`:
        *   Method signatures aligned with remote data source changes (separate IDs, `isDefault` handling, `createRole` now returns `Result<String>`, `getRoleDetails` returns `Result<Role?>`).

4.  **New UseCases Implemented**:
    *   **For Project Members**:
        *   `AddProjectMemberUseCase`
        *   `GetProjectMemberUseCase`
        *   `GetProjectMembersUseCase` (with filtering by role and sorting by name/join date)
        *   `UpdateProjectMemberUseCase` (handles role and channel access updates)
        *   `RemoveProjectMemberUseCase`
        *   `GetMembersInRoleUseCase`
        *   `MemberSortOption` enum created.
    *   **For Project Roles**:
        *   `CreateProjectRoleUseCase` (handles `isDefault`, returns role ID)
        *   `GetProjectRoleUseCase`
        *   `GetProjectRolesUseCase` (with filtering by `isDefault` and sorting by name)
        *   `UpdateProjectRoleUseCase` (handles partial updates for `name`, `permissions`, `isDefault`)
        *   `DeleteProjectRoleUseCase`
        *   `RoleSortOption` enum created.

5.  **Unit Tests**:
    *   I added comprehensive unit tests for all new and modified methods in the repository implementations (`ProjectMemberRepositoryImplTest.kt`, `ProjectRoleRepositoryImplTest.kt`).
    *   I also added unit tests for all new UseCases, covering various scenarios, filtering, sorting, and interaction with mocked repositories.
    *   I confirmed that tests for `memberIds` synchronization in `ProjectMemberRemoteDataSourceImplTest.kt` are in place.

This addresses the issue of providing flexible and robust management of your project members and roles, and improves data consistency related to the project's `memberIds` list.