### PR TITLE
feat: Implement profile and auth screen enhancements

### DIFF
--- a/feature/feature_auth/src/test/java/com/example/feature_auth/viewmodel/FindPasswordViewModelTest.kt
+++ b/feature/feature_auth/src/test/java/com/example/feature_auth/viewmodel/FindPasswordViewModelTest.kt
@@ -1,12 +1,21 @@
 package com.example.feature_auth.viewmodel
 
-import com.example.data.repository.FakeAuthRepository
+import app.cash.turbine.test
 import com.example.data.util.CoroutinesTestRule
-import com.example.data.util.FlowTestExtensions.EventCollector
-import com.example.data.util.FlowTestExtensions.getValue
+// import com.example.data.util.FlowTestExtensions.getValue // Replaced by Turbine state access
+import com.example.domain.usecase.auth.GetAuthErrorMessageUseCase
+import com.example.domain.usecase.auth.RequestPasswordResetUseCase
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertNotNull
+import junit.framework.TestCase.assertNull
+import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
-import org.junit.Assert.*
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -17,325 +26,147 @@ import org.junit.Test
  * 이 테스트는 순수 JUnit 환경에서 FindPasswordViewModel의 기능을 검증합니다.
  * FakeAuthRepository를 사용하여 외부 의존성 없이 테스트합니다.
  */
-@ExperimentalCoroutinesApi
+@OptIn(ExperimentalCoroutinesApi::class)
 class FindPasswordViewModelTest {
 
-    // Coroutines 테스트 환경 설정
     @get:Rule
     val coroutinesTestRule = CoroutinesTestRule()
 
-    // 테스트 대상 (System Under Test)
     private lateinit var viewModel: FindPasswordViewModel
+    private lateinit var requestPasswordResetUseCase: RequestPasswordResetUseCase
+    private lateinit var getAuthErrorMessageUseCase: GetAuthErrorMessageUseCase
 
-    // Fake Repository
-    private lateinit var fakeAuthRepository: FakeAuthRepository
-
-    // 테스트 데이터
     private val testEmail = "test@example.com"
-    private val testAuthCode = "123456"
-    private val testNewPassword = "P@ssw0rd123"
 
-    /**
-     * 테스트 초기화
-     */
     @Before
     fun setup() {
-        // Fake Repository 초기화
-        fakeAuthRepository = FakeAuthRepository()
+        requestPasswordResetUseCase = mockk()
+        getAuthErrorMessageUseCase = mockk()
         
-        // ViewModel 초기화 (의존성 주입)
-        // 현재 FindPasswordViewModel의 구현에서는 authRepository가 주석 처리되어 있으므로,
-        // 테스트에서는 이 점을 고려해야 함
-        viewModel = FindPasswordViewModel(/*fakeAuthRepository*/)
+        viewModel = FindPasswordViewModel(
+            requestPasswordResetUseCase,
+            getAuthErrorMessageUseCase
+        )
     }
 
-    /**
-     * 초기 상태 테스트
-     */
     @Test
-    fun `초기 상태는 모든 필드가 비어있고 상태값이 초기화되어야 함`() = coroutinesTestRule.runBlockingTest {
-        // Given: 초기화된 ViewModel (setup에서 이미 초기화됨)
-
-        // When: UI 상태 가져오기
-        val initialState = viewModel.uiState.getValue()
-
-        // Then: 초기 상태 확인
+    fun `초기 상태는 email이 비어있고 isEmailSent는 false여야 함`() = runTest {
+        val initialState = viewModel.uiState.value
         assertEquals("", initialState.email)
-        assertEquals("", initialState.authCode)
-        assertEquals("", initialState.newPassword)
-        assertEquals("", initialState.newPasswordConfirm)
-        assertFalse(initialState.isPasswordVisible)
         assertFalse(initialState.isEmailSent)
-        assertFalse(initialState.isEmailVerified)
         assertFalse(initialState.isLoading)
         assertNull(initialState.errorMessage)
-        assertFalse(initialState.passwordChangeSuccess)
     }
 
-    /**
-     * 이메일 입력 테스트
-     */
     @Test
-    fun `이메일 입력 시 상태가 업데이트되어야 함`() = coroutinesTestRule.runBlockingTest {
-        // Given: 초기 상태의 ViewModel
-        val testEmail = "test@example.com"
+    fun `onEmailChange는 uiState의 email을 업데이트하고 errorMessage를 null로 설정해야 함`() = runTest {
+        // Set an initial error message to ensure it's cleared
+        viewModel.onEmailChange("initial@example.com") // To set some initial email
+        // Manually set error message for test condition as onEmailChange clears it
+        val currentOnErrorState = viewModel.uiState.value.copy(errorMessage = "Old Error")
+        // This is tricky; direct state update is not how VM works. Better to test the effect.
+        // Let's assume an error was there from a previous failed operation.
+        // We can't directly set uiState. So, we'll check that onEmailChange clears any hypothetical error.
 
-        // When: 이메일 입력
         viewModel.onEmailChange(testEmail)
-
-        // Then: 상태 업데이트 확인
-        val state = viewModel.uiState.getValue()
+        val state = viewModel.uiState.value
         assertEquals(testEmail, state.email)
-        assertNull(state.errorMessage)
+        assertNull(state.errorMessage) // Crucial: error should be cleared
     }
 
-    /**
-     * 인증코드 입력 테스트
-     */
     @Test
-    fun `인증코드 입력 시 상태가 업데이트되어야 함`() = coroutinesTestRule.runBlockingTest {
-        // Given: 초기 상태의 ViewModel
-        val testAuthCode = "123456"
-
-        // When: 인증코드 입력
-        viewModel.onAuthCodeChange(testAuthCode)
-
-        // Then: 상태 업데이트 확인
-        val state = viewModel.uiState.getValue()
-        assertEquals(testAuthCode, state.authCode)
-        assertNull(state.errorMessage)
-    }
-
-    /**
-     * 새 비밀번호 입력 테스트
-     */
-    @Test
-    fun `새 비밀번호 입력 시 상태가 업데이트되어야 함`() = coroutinesTestRule.runBlockingTest {
-        // Given: 초기 상태의 ViewModel
-        val testPassword = "P@ssw0rd123"
-
-        // When: 새 비밀번호 입력
-        viewModel.onNewPasswordChange(testPassword)
-
-        // Then: 상태 업데이트 확인
-        val state = viewModel.uiState.getValue()
-        assertEquals(testPassword, state.newPassword)
-        assertNull(state.errorMessage)
-    }
-
-    /**
-     * 새 비밀번호 확인 입력 테스트
-     */
-    @Test
-    fun `새 비밀번호 확인 입력 시 상태가 업데이트되어야 함`() = coroutinesTestRule.runBlockingTest {
-        // Given: 초기 상태의 ViewModel
-        val testPasswordConfirm = "P@ssw0rd123"
-
-        // When: 새 비밀번호 확인 입력
-        viewModel.onNewPasswordConfirmChange(testPasswordConfirm)
-
-        // Then: 상태 업데이트 확인
-        val state = viewModel.uiState.getValue()
-        assertEquals(testPasswordConfirm, state.newPasswordConfirm)
-        assertNull(state.errorMessage)
-    }
-
-    /**
-     * 비밀번호 가시성 토글 테스트
-     */
-    @Test
-    fun `비밀번호 가시성 토글 시 상태가 전환되어야 함`() = coroutinesTestRule.runBlockingTest {
-        // Given: 초기 상태의 ViewModel
-        assertFalse(viewModel.uiState.getValue().isPasswordVisible)
-
-        // When: 비밀번호 가시성 토글
-        viewModel.onPasswordVisibilityToggle()
-
-        // Then: 가시성 상태 변경 확인
-        assertTrue(viewModel.uiState.getValue().isPasswordVisible)
-
-        // When: 다시 토글
-        viewModel.onPasswordVisibilityToggle()
-
-        // Then: 다시 원래 상태로 돌아옴
-        assertFalse(viewModel.uiState.getValue().isPasswordVisible)
-    }
-
-    /**
-     * 잘못된 이메일 형식으로 인증번호 요청 테스트
-     */
-    @Test
-    fun `잘못된 이메일 형식으로 인증번호 요청 시 오류 메시지가 표시되어야 함`() = coroutinesTestRule.runBlockingTest {
-        // Given: 유효하지 않은 이메일 설정
-        viewModel.onEmailChange("invalid-email")
-
-        // When: 인증번호 전송 요청
-        viewModel.onSendAuthCodeClick()
-
-        // Then: 오류 메시지 확인
-        val state = viewModel.uiState.getValue()
-        assertNotNull(state.errorMessage)
-        assertEquals("올바른 이메일 주소를 입력해주세요.", state.errorMessage)
+    fun `requestPasswordResetEmail 빈 이메일로 호출 시 오류 메시지 표시`() = runTest {
+        viewModel.onEmailChange("") // Blank email
+        viewModel.requestPasswordResetEmail()
+        val state = viewModel.uiState.value
+        assertEquals("올바른 이메일 형식이 아닙니다.", state.errorMessage)
         assertFalse(state.isEmailSent)
+        coVerify(exactly = 0) { requestPasswordResetUseCase(any()) }
+    }
+    
+    @Test
+    fun `requestPasswordResetEmail 잘못된 형식의 이메일로 호출 시 오류 메시지 표시`() = runTest {
+        viewModel.onEmailChange("invalid-email")
+        viewModel.requestPasswordResetEmail()
+        val state = viewModel.uiState.value
+        assertEquals("올바른 이메일 형식이 아닙니다.", state.errorMessage)
+        assertFalse(state.isEmailSent)
+        coVerify(exactly = 0) { requestPasswordResetUseCase(any()) }
     }
 
-    /**
-     * 성공적인 인증번호 요청 테스트
-     */
     @Test
-    fun `올바른 이메일로 인증번호 요청 시 성공 상태가 설정되어야 함`() = coroutinesTestRule.runBlockingTest {
-        // Given: 이벤트 수집기 설정 및 올바른 이메일 입력
-        val eventCollector = EventCollector<FindPasswordEvent>()
-        eventCollector.collectFrom(coroutinesTestRule.testCoroutineScope, viewModel.eventFlow)
+    fun `requestPasswordResetEmail 성공 시 isEmailSent true 및 스낵바 이벤트 발생`() = runTest {
+        coEvery { requestPasswordResetUseCase(testEmail) } returns Result.success(Unit)
+        viewModel.onEmailChange(testEmail)
+
+        viewModel.eventFlow.test {
+            viewModel.requestPasswordResetEmail()
+            runCurrent() // Ensure coroutines complete
+
+            val state = viewModel.uiState.value
+            assertTrue(state.isEmailSent)
+            assertFalse(state.isLoading)
+            assertNull(state.errorMessage)
+
+            assertEquals(FindPasswordEvent.ShowSnackbar("이메일이 전송되었습니다."), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+        coVerify { requestPasswordResetUseCase(testEmail) }
+    }
+
+    @Test
+    fun `requestPasswordResetEmail 실패 시 errorMessage 설정 및 isEmailSent false 유지`() = runTest {
+        val exception = RuntimeException("Network error")
+        val specificErrorMessage = "네트워크 오류가 발생했습니다."
+        coEvery { requestPasswordResetUseCase(testEmail) } returns Result.failure(exception)
+        coEvery { getAuthErrorMessageUseCase.getPasswordResetErrorMessage(exception) } returns specificErrorMessage
         
         viewModel.onEmailChange(testEmail)
 
-        // When: 인증번호 전송 요청
-        viewModel.onSendAuthCodeClick()
+        viewModel.requestPasswordResetEmail()
+        runCurrent()
 
-        // Then: 성공 상태 확인
-        val state = viewModel.uiState.getValue()
-        assertTrue(state.isEmailSent)
+        val state = viewModel.uiState.value
+        assertFalse(state.isEmailSent)
         assertFalse(state.isLoading)
+        assertEquals(specificErrorMessage, state.errorMessage)
         
-        // 스낵바 이벤트 발생 확인
-        assertTrue(eventCollector.events.isNotEmpty())
-        val event = eventCollector.events.first()
-        assertTrue(event is FindPasswordEvent.ShowSnackbar)
-        assertEquals("인증번호가 전송되었습니다.", (event as FindPasswordEvent.ShowSnackbar).message)
+        coVerify { requestPasswordResetUseCase(testEmail) }
+        coVerify { getAuthErrorMessageUseCase.getPasswordResetErrorMessage(exception) }
     }
 
-    /**
-     * 인증코드 미입력 검증 테스트
-     */
     @Test
-    fun `인증코드 미입력 시 오류 메시지가 표시되어야 함`() = coroutinesTestRule.runBlockingTest {
-        // Given: 이메일 입력 및 인증번호 전송 상태 설정
-        viewModel.onEmailChange(testEmail)
-        viewModel.onSendAuthCodeClick() // isEmailSent를 true로 설정
-        
-        // 인증번호 미입력 (빈 상태 유지)
-
-        // When: 인증번호 확인 요청
-        viewModel.onConfirmAuthCodeClick()
-
-        // Then: 오류 메시지 확인
-        val state = viewModel.uiState.getValue()
-        assertNotNull(state.errorMessage)
-        assertEquals("인증번호를 입력해주세요.", state.errorMessage)
-        assertFalse(state.isEmailVerified)
+    fun `onDoneClicked 시 NavigateBack 이벤트 발생`() = runTest {
+        viewModel.eventFlow.test {
+            viewModel.onDoneClicked()
+            assertEquals(FindPasswordEvent.NavigateBack, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
     }
-
-    /**
-     * 성공적인 인증코드 확인 테스트
-     */
+    
     @Test
-    fun `올바른 인증코드 입력 시 인증 성공 상태가 설정되어야 함`() = coroutinesTestRule.runBlockingTest {
-        // Given: 이벤트 수집기 설정 및 이메일, 인증코드 입력
-        val eventCollector = EventCollector<FindPasswordEvent>()
-        eventCollector.collectFrom(coroutinesTestRule.testCoroutineScope, viewModel.eventFlow)
-        
-        viewModel.onEmailChange(testEmail)
-        viewModel.onSendAuthCodeClick() // isEmailSent를 true로 설정
-        viewModel.onAuthCodeChange(testAuthCode)
-
-        // When: 인증번호 확인 요청
-        viewModel.onConfirmAuthCodeClick()
-
-        // Then: 성공 상태 확인
-        val state = viewModel.uiState.getValue()
-        assertTrue(state.isEmailVerified)
-        assertFalse(state.isLoading)
-        
-        // 스낵바 이벤트 발생 확인
-        assertTrue(eventCollector.events.isNotEmpty())
-        val event = eventCollector.events.last() // 마지막 이벤트(인증 성공 메시지)
-        assertTrue(event is FindPasswordEvent.ShowSnackbar)
-        assertEquals("인증되었습니다. 새 비밀번호를 입력하세요.", (event as FindPasswordEvent.ShowSnackbar).message)
+    fun `onBackClick 시 NavigateBack 이벤트 발생`() = runTest {
+         viewModel.eventFlow.test {
+            viewModel.onBackClick()
+            assertEquals(FindPasswordEvent.NavigateBack, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
-    /**
-     * 비밀번호 미입력 검증 테스트
-     */
     @Test
-    fun `새 비밀번호 미입력 시 오류 메시지가 표시되어야 함`() = coroutinesTestRule.runBlockingTest {
-        // Given: 이메일 인증까지 완료된 상태 설정
+    fun `errorMessageShown 시 errorMessage가 null로 설정됨`() = runTest {
+        // Simulate an error state first
+        coEvery { requestPasswordResetUseCase(testEmail) } returns Result.failure(RuntimeException("Error"))
+        coEvery { getAuthErrorMessageUseCase.getPasswordResetErrorMessage(any()) } returns "Some error"
         viewModel.onEmailChange(testEmail)
-        viewModel.onSendAuthCodeClick()
-        viewModel.onAuthCodeChange(testAuthCode)
-        viewModel.onConfirmAuthCodeClick()
-        
-        // 비밀번호 미입력 (빈 상태 유지)
+        viewModel.requestPasswordResetEmail()
+        runCurrent()
+        assertNotNull(viewModel.uiState.value.errorMessage)
 
-        // When: 비밀번호 변경 요청
-        viewModel.onChangePasswordClick()
-
-        // Then: 오류 메시지 확인
-        val state = viewModel.uiState.getValue()
-        assertNotNull(state.errorMessage)
-        assertEquals("새 비밀번호를 모두 입력해주세요.", state.errorMessage)
-        assertFalse(state.passwordChangeSuccess)
+        // Now test errorMessageShown
+        viewModel.errorMessageShown()
+        assertNull(viewModel.uiState.value.errorMessage)
     }
 
-    /**
-     * 비밀번호 불일치 테스트
-     */
-    @Test
-    fun `새 비밀번호와 확인이 일치하지 않을 때 오류 메시지가 표시되어야 함`() = coroutinesTestRule.runBlockingTest {
-        // Given: 이메일 인증까지 완료된 상태 및 불일치하는 비밀번호 설정
-        viewModel.onEmailChange(testEmail)
-        viewModel.onSendAuthCodeClick()
-        viewModel.onAuthCodeChange(testAuthCode)
-        viewModel.onConfirmAuthCodeClick()
-        
-        viewModel.onNewPasswordChange(testNewPassword)
-        viewModel.onNewPasswordConfirmChange("DifferentPassword123!")
-
-        // When: 비밀번호 변경 요청
-        viewModel.onChangePasswordClick()
-
-        // Then: 오류 메시지 확인
-        val state = viewModel.uiState.getValue()
-        assertNotNull(state.errorMessage)
-        assertEquals("새 비밀번호가 일치하지 않습니다.", state.errorMessage)
-        assertFalse(state.passwordChangeSuccess)
-    }
-
-    /**
-     * 성공적인 비밀번호 변경 테스트
-     */
-    @Test
-    fun `올바른 정보로 비밀번호 변경 시 성공 상태가 설정되고 이벤트가 발생해야 함`() = coroutinesTestRule.runBlockingTest {
-        // Given: 이벤트 수집기 설정 및 모든 필수 정보 입력
-        val eventCollector = EventCollector<FindPasswordEvent>()
-        eventCollector.collectFrom(coroutinesTestRule.testCoroutineScope, viewModel.eventFlow)
-        
-        viewModel.onEmailChange(testEmail)
-        viewModel.onSendAuthCodeClick()
-        viewModel.onAuthCodeChange(testAuthCode)
-        viewModel.onConfirmAuthCodeClick()
-        viewModel.onNewPasswordChange(testNewPassword)
-        viewModel.onNewPasswordConfirmChange(testNewPassword)
-
-        // When: 비밀번호 변경 요청
-        viewModel.onChangePasswordClick()
-
-        // Then: 성공 상태 확인
-        val state = viewModel.uiState.getValue()
-        assertTrue(state.passwordChangeSuccess)
-        assertFalse(state.isLoading)
-        
-        // 이벤트 발생 확인 (최소 2개: 스낵바 메시지 + 네비게이션)
-        assertTrue(eventCollector.events.size >= 2)
-        
-        // 스낵바 이벤트 확인
-        val snackbarEvent = eventCollector.events.findLast { it is FindPasswordEvent.ShowSnackbar }
-        assertNotNull(snackbarEvent)
-        assertEquals("비밀번호가 성공적으로 변경되었습니다.", (snackbarEvent as FindPasswordEvent.ShowSnackbar).message)
-        
-        // 네비게이션 이벤트 확인
-        val navigationEvent = eventCollector.events.findLast { it is FindPasswordEvent.NavigateBack }
-        assertNotNull(navigationEvent)
-        assertTrue(navigationEvent is FindPasswordEvent.NavigateBack)
-    }
-} 
+    // Removed obsolete tests for authCode, newPassword, password visibility, etc.
+}

--- a/feature/feature_profile/src/main/java/com/example/feature_profile/viewmodel/ChangeStatusViewModel.kt
+++ b/feature/feature_profile/src/main/java/com/example/feature_profile/viewmodel/ChangeStatusViewModel.kt
@@ -101,8 +101,8 @@ class ChangeStatusViewModel @Inject constructor(
             _uiState.update { it.copy(isUpdating = true, error = null) }
             _eventFlow.emit(ChangeStatusEvent.ShowSnackbar("상태 변경 중..."))
 
-            // UseCase는 String 매개변수를 기대하므로 displayName 사용
-            val result = updateUserStatusUseCase(statusToUpdate.name)
+            // UseCase는 UserStatus.value (e.g., "ONLINE")를 사용해야 합니다.
+            val result = updateUserStatusUseCase(statusToUpdate.value)
 
             if (result.isSuccess) {
                 _uiState.update {
@@ -112,6 +112,7 @@ class ChangeStatusViewModel @Inject constructor(
                         updateSuccess = true
                     )
                 }
+                // The snackbar can still use .name for display as per instructions
                 _eventFlow.emit(ChangeStatusEvent.ShowSnackbar("상태가 '${statusToUpdate.name}'(으)로 변경되었습니다."))
                 _eventFlow.emit(ChangeStatusEvent.DismissDialog) // 성공 시 다이얼로그 닫기
             } else {


### PR DESCRIPTION
This commit introduces several improvements to the profile and authentication features:

1.  **In-Place Status Message Editing (Profile Screen):**
    *   You can now edit your status message directly on the profile screen by tapping on it.
    *   The input field has a 50-character limit and updates on focus loss or when the "Done" IME action is triggered.
    *   `ProfileViewModel` handles the update via `UpdateUserStatusUseCase`.

2.  **Enhanced Change Status Indicator (Profile Screen & Dialog):**
    *   The "Change Status" option in the profile screen now opens a dialog (`ChangeStatusDialog`).
    *   The dialog UI has been updated to use selectable rows with background changes instead of radio buttons.
    *   `ChangeStatusViewModel` now uses `UserStatus.value` (e.g., "ONLINE") when calling `UpdateUserStatusUseCase` to update Firestore.
    *   A snackbar confirms the status change on the profile screen.

3.  **Refactored Password Reset Flow (Find Password Screen):**
    *   The password reset process has been simplified to align with Firebase's web-based reset.
    *   You enter your email and click "Send".
    *   The UI then indicates that an email has been sent and provides a "Done" button.
    *   Clicking "Done" navigates you back to the login screen.
    *   The multi-step auth code and new password entry within the app has been removed.

4.  **Unit Tests:**
    *   Added and updated unit tests for `ProfileViewModel`, `ChangeStatusViewModel`, and `FindPasswordViewModel` to cover the new logic, state changes, and interactions with use cases, using MockK and Turbine.