### PR TITLE
Refactor DMChannel to align with DDD principles

### DIFF
--- a/domain/src/main/java/com/example/domain/event/dmchannel/DMChannelCreatedEvent.kt
+++ b/domain/src/main/java/com/example/domain/event/dmchannel/DMChannelCreatedEvent.kt
@@ -1,0 +1,16 @@
+package com.example.domain.event.dmchannel
+
+import com.example.domain.event.DomainEvent
+import com.example.domain.model.vo.dmchannel.DMChannelId
+import java.time.Instant
+
+/**
+ * Represents an event that is triggered when a new DMChannel is created.
+ *
+ * @property dmChannelId The ID of the newly created DM channel.
+ * @property occurredOn The timestamp when the event occurred.
+ */
+data class DMChannelCreatedEvent(
+    val dmChannelId: DMChannelId,
+    override val occurredOn: Instant = Instant.now()
+) : DomainEvent

--- a/domain/src/main/java/com/example/domain/event/dmchannel/DMChannelLastMessageUpdatedEvent.kt
+++ b/domain/src/main/java/com/example/domain/event/dmchannel/DMChannelLastMessageUpdatedEvent.kt
@@ -1,0 +1,16 @@
+package com.example.domain.event.dmchannel
+
+import com.example.domain.event.DomainEvent
+import com.example.domain.model.vo.dmchannel.DMChannelId
+import java.time.Instant
+
+/**
+ * Represents an event that is triggered when the last message of a DMChannel is updated.
+ *
+ * @property dmChannelId The ID of the DM channel whose last message was updated.
+ * @property occurredOn The timestamp when the event occurred.
+ */
+data class DMChannelLastMessageUpdatedEvent(
+    val dmChannelId: DMChannelId,
+    override val occurredOn: Instant = Instant.now()
+) : DomainEvent

--- a/domain/src/main/java/com/example/domain/event/dmchannel/DMChannelParticipantsChangedEvent.kt
+++ b/domain/src/main/java/com/example/domain/event/dmchannel/DMChannelParticipantsChangedEvent.kt
@@ -1,0 +1,19 @@
+package com.example.domain.event.dmchannel
+
+import com.example.domain.event.DomainEvent
+import com.example.domain.model.vo.dmchannel.DMChannelId
+import com.example.domain.model.vo.DocumentId
+import java.time.Instant
+
+/**
+ * Represents an event that is triggered when the participant list of a DMChannel changes.
+ *
+ * @property dmChannelId The ID of the DM channel whose participants changed.
+ * @property participants The new list of participants in the DM channel.
+ * @property occurredOn The timestamp when the event occurred.
+ */
+data class DMChannelParticipantsChangedEvent(
+    val dmChannelId: DMChannelId,
+    val participants: List<DocumentId>,
+    override val occurredOn: Instant = Instant.now()
+) : DomainEvent

--- a/domain/src/main/java/com/example/domain/model/base/DMChannel.kt
+++ b/domain/src/main/java/com/example/domain/model/base/DMChannel.kt
@@ -1,17 +1,162 @@
 package com.example.domain.model.base
 
-import com.google.firebase.Timestamp
-import com.google.firebase.firestore.DocumentId
-import com.google.firebase.firestore.ServerTimestamp
+import com.example.domain.event.AggregateRoot
+import com.example.domain.event.DomainEvent
+import com.example.domain.event.dmchannel.DMChannelCreatedEvent
+import com.example.domain.event.dmchannel.DMChannelLastMessageUpdatedEvent
+import com.example.domain.model.vo.DocumentId
+import com.example.domain.model.vo.dmchannel.DMChannelId
+import com.example.domain.model.vo.dmchannel.DMChannelLastMessagePreview
 import java.time.Instant
 
-data class DMChannel(
-    @DocumentId val id: String = "",
-    // userId1, userId2 대신 참여자 목록으로 관리하면 확장성 및 쿼리에 유리합니다.
-    val participants: List<String> = emptyList(),
-    val lastMessagePreview: String? = null,
-    val lastMessageTimestamp: Instant? = null,
-    val createdAt: Instant? = null,
-    val updatedAt: Instant? = null,
-)
+/**
+ * Represents a Direct Message (DM) channel between users.
+ *
+ * A DMChannel is an aggregate root that manages the state and business rules
+ * for direct messaging conversations.
+ *
+ * @property id The unique identifier of the DM channel.
+ * @property participants The list of user IDs participating in this DM channel.
+ * @property lastMessagePreview A preview of the last message sent in the channel.
+ * @property lastMessageTimestamp The timestamp of the last message.
+ * @property createdAt The timestamp when the channel was created.
+ * @property updatedAt The timestamp when the channel was last updated.
+ */
+class DMChannel private constructor(
+    id: DMChannelId,
+    participants: List<DocumentId>,
+    lastMessagePreview: DMChannelLastMessagePreview?,
+    lastMessageTimestamp: Instant?,
+    createdAt: Instant,
+    updatedAt: Instant
+) : AggregateRoot {
+
+    /** Unique identifier of the DM channel. */
+    val id: DMChannelId = id
+    /** List of user document IDs participating in this DM channel. */
+    var participants: List<DocumentId> = participants
+        private set
+    /** Preview of the last message sent in the channel. Null if no messages yet. */
+    var lastMessagePreview: DMChannelLastMessagePreview? = lastMessagePreview
+        private set
+    /** Timestamp of the last message sent in the channel. Null if no messages yet. */
+    var lastMessageTimestamp: Instant? = lastMessageTimestamp
+        private set
+    /** Timestamp indicating when the DM channel was created. */
+    val createdAt: Instant = createdAt
+    /** Timestamp indicating when the DM channel was last updated, either by a new message or participant change. */
+    var updatedAt: Instant = updatedAt
+        private set
+
+    private val _domainEvents: MutableList<DomainEvent> = mutableListOf()
+
+    override fun pullDomainEvents(): List<DomainEvent> {
+        val events = _domainEvents.toList() // Make a copy
+        _domainEvents.clear()
+        return events
+    }
+
+    override fun clearDomainEvents() {
+        _domainEvents.clear()
+    }
+
+    /**
+     * Updates the preview and timestamp of the last message in this DM channel.
+     * Generates a [DMChannelLastMessageUpdatedEvent].
+     *
+     * @param newPreview The new message preview. Can be null.
+     * @param newTimestamp The timestamp of the new last message. Can be null.
+     */
+    fun updateLastMessage(newPreview: DMChannelLastMessagePreview?, newTimestamp: Instant?) {
+        // Optional: Add validation, e.g., if newTimestamp is null, newPreview should also be null.
+        // Or if newTimestamp is not null, it should be later than or equal to the current lastMessageTimestamp if it exists.
+        // For now, direct update as per plan.
+
+        this.lastMessagePreview = newPreview
+        this.lastMessageTimestamp = newTimestamp
+        this.updatedAt = Instant.now()
+        this._domainEvents.add(DMChannelLastMessageUpdatedEvent(this.id))
+    }
+
+    // fun addParticipant(participantId: DocumentId, currentTime: Instant)
+    // fun removeParticipant(participantId: DocumentId, currentTime: Instant)
+    // These methods would also update `updatedAt` and potentially raise domain events.
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        other as DMChannel
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id.hashCode()
+    }
+
+    companion object {
+        /**
+         * Creates a new DMChannel instance.
+         *
+         * @param id The unique identifier for the new channel.
+         * @param initialParticipants The initial list of participants in the channel. Must contain at least two participants.
+         * @param currentTime The current time, used to set creation and update timestamps.
+         * @return A new DMChannel instance.
+         * @throws IllegalArgumentException if `initialParticipants` has less than two participants.
+         */
+        fun create(
+            id: DMChannelId,
+            initialParticipants: List<DocumentId>,
+            currentTime: Instant
+        ): DMChannel {
+            require(initialParticipants.size >= 2) { "DMChannel must have at least two participants." }
+            // Ensure participants are distinct, if not already handled or guaranteed by caller
+            val distinctParticipants = initialParticipants.distinct()
+            require(distinctParticipants.size == initialParticipants.size) { "Participant IDs must be unique."}
+            require(distinctParticipants.size >= 2) { "DMChannel must have at least two distinct participants."}
+
+
+            val channel = DMChannel(
+                id = id,
+                participants = distinctParticipants, // Use distinct participants
+                lastMessagePreview = null,
+                lastMessageTimestamp = null,
+                createdAt = currentTime,
+                updatedAt = currentTime
+            )
+            channel._domainEvents.add(DMChannelCreatedEvent(channel.id)) // Add this line
+            return channel
+        }
+
+        /**
+         * Reconstructs a DMChannel instance from a data source.
+         *
+         * This method is intended for use when loading an existing channel from persistence.
+         *
+         * @param id The unique identifier of the channel.
+         * @param participants The list of participants in the channel.
+         * @param lastMessagePreview A preview of the last message.
+         * @param lastMessageTimestamp The timestamp of the last message.
+         * @param createdAt The timestamp when the channel was created.
+         * @param updatedAt The timestamp when the channel was last updated.
+         * @return A DMChannel instance reconstructed from the provided data.
+         */
+        fun fromDataSource(
+            id: DMChannelId,
+            participants: List<DocumentId>,
+            lastMessagePreview: DMChannelLastMessagePreview?,
+            lastMessageTimestamp: Instant?,
+            createdAt: Instant,
+            updatedAt: Instant
+        ): DMChannel {
+            return DMChannel(
+                id = id,
+                participants = participants,
+                lastMessagePreview = lastMessagePreview,
+                lastMessageTimestamp = lastMessageTimestamp,
+                createdAt = createdAt,
+                updatedAt = updatedAt
+            )
+        }
+    }
+}
 

--- a/domain/src/main/java/com/example/domain/model/vo/dmchannel/DMChannelId.kt
+++ b/domain/src/main/java/com/example/domain/model/vo/dmchannel/DMChannelId.kt
@@ -1,0 +1,15 @@
+package com.example.domain.model.vo.dmchannel
+
+import kotlin.jvm.JvmInline
+
+/**
+ * Represents the unique identifier for a DM channel.
+ *
+ * This value class wraps a [String] and ensures that the ID is not blank.
+ */
+@JvmInline
+value class DMChannelId(val value: String) {
+    init {
+        require(value.isNotBlank()) { "DMChannel ID는 비어있을 수 없습니다." }
+    }
+}

--- a/domain/src/main/java/com/example/domain/model/vo/dmchannel/DMChannelLastMessagePreview.kt
+++ b/domain/src/main/java/com/example/domain/model/vo/dmchannel/DMChannelLastMessagePreview.kt
@@ -1,0 +1,11 @@
+package com.example.domain.model.vo.dmchannel
+
+import kotlin.jvm.JvmInline
+
+/**
+ * Represents a preview of the last message in a DM channel.
+ *
+ * This value class wraps a [String] and is used to display a snippet of the most recent message.
+ */
+@JvmInline
+value class DMChannelLastMessagePreview(val value: String)


### PR DESCRIPTION
This commit refactors the DMChannel class to follow the established Domain-Driven Design patterns:

- DMChannel is now an AggregateRoot.
- Constructor is private, with object creation handled by `create` and `fromDataSource` factory methods in a companion object.
- Properties are declared in the class body. Primitive types for domain concepts are wrapped in Value Objects:
    - `id` is now `DMChannelId`.
    - `participants` is `List<DocumentId>`.
    - `lastMessagePreview` is `DMChannelLastMessagePreview?`.
- Domain events (`DMChannelCreatedEvent`, `DMChannelLastMessageUpdatedEvent`) are defined and emitted when the entity's state changes.
- `DMChannelParticipantsChangedEvent` is defined for future use.
- KDoc documentation has been added to all new and modified classes, methods, and properties.
- Firestore-specific annotations have been removed from the domain model.
- `DMChannel` is no longer a data class and implements `equals()` and `hashCode()` based on its `id`.