### PR TITLE
Refactor DMWrapper.kt to align with DDD principles

### DIFF
--- a/domain/src/main/java/com/example/domain/event/dmwrapper/DMWrapperCreatedEvent.kt
+++ b/domain/src/main/java/com/example/domain/event/dmwrapper/DMWrapperCreatedEvent.kt
@@ -1,0 +1,10 @@
+package com.example.domain.event.dmwrapper
+
+import com.example.domain.event.DomainEvent
+import com.example.domain.model.vo.dmwrapper.DMWrapperId
+import java.time.Instant
+
+data class DMWrapperCreatedEvent(
+    val dmWrapperId: DMWrapperId,
+    override val occurredOn: Instant = Instant.now()
+) : DomainEvent

--- a/domain/src/main/java/com/example/domain/event/dmwrapper/DMWrapperOtherUserChangedEvent.kt
+++ b/domain/src/main/java/com/example/domain/event/dmwrapper/DMWrapperOtherUserChangedEvent.kt
@@ -1,0 +1,12 @@
+package com.example.domain.event.dmwrapper
+
+import com.example.domain.event.DomainEvent
+import com.example.domain.model.vo.dmwrapper.DMWrapperId
+import com.example.domain.model.vo.DocumentId // Added this import
+import java.time.Instant
+
+data class DMWrapperOtherUserChangedEvent(
+    val dmWrapperId: DMWrapperId,
+    val newOtherUserId: DocumentId, // Changed type to DocumentId
+    override val occurredOn: Instant = Instant.now()
+) : DomainEvent

--- a/domain/src/main/java/com/example/domain/model/base/DMWrapper.kt
+++ b/domain/src/main/java/com/example/domain/model/base/DMWrapper.kt
@@ -1,10 +1,61 @@
 package com.example.domain.model.base
 
-import com.google.firebase.firestore.DocumentId
+import com.example.domain.event.AggregateRoot
+import com.example.domain.event.DomainEvent
+import com.example.domain.model.vo.DocumentId
+import com.example.domain.model.vo.dmwrapper.DMWrapperId
+import com.example.domain.event.dmwrapper.DMWrapperCreatedEvent
+import com.example.domain.event.dmwrapper.DMWrapperOtherUserChangedEvent
 import java.time.Instant
 
-data class DMWrapper(
-    @DocumentId val dmChannelId: String = "",
-    val otherUserId: String = ""
-)
+class DMWrapper private constructor(
+    dmChannelId: DMWrapperId,
+    otherUserId: DocumentId,
+    createdAt: Instant,
+    updatedAt: Instant
+) : AggregateRoot {
 
+    private val _domainEvents: MutableList<DomainEvent> = mutableListOf()
+
+    val dmChannelId: DMWrapperId = dmChannelId
+    var otherUserId: DocumentId = otherUserId
+        private set
+    val createdAt: Instant = createdAt
+    var updatedAt: Instant = updatedAt
+        private set
+
+    override fun pullDomainEvents(): List<DomainEvent> {
+        val events = _domainEvents.toList()
+        _domainEvents.clear()
+        return events
+    }
+
+    override fun clearDomainEvents() {
+        _domainEvents.clear()
+    }
+
+    fun changeOtherUser(newOtherUserId: DocumentId) {
+        if (this.otherUserId == newOtherUserId) return
+
+        this.otherUserId = newOtherUserId
+        this.updatedAt = Instant.now()
+        _domainEvents.add(DMWrapperOtherUserChangedEvent(this.dmChannelId, newOtherUserId))
+    }
+
+    companion object {
+        fun create(
+            dmChannelId: DMWrapperId,
+            otherUserId: DocumentId
+        ): DMWrapper {
+            val now = Instant.now()
+            val dmWrapper = DMWrapper(
+                dmChannelId = dmChannelId,
+                otherUserId = otherUserId,
+                createdAt = now,
+                updatedAt = now
+            )
+            dmWrapper._domainEvents.add(DMWrapperCreatedEvent(dmWrapper.dmChannelId))
+            return dmWrapper
+        }
+    }
+}

--- a/domain/src/main/java/com/example/domain/model/vo/dmwrapper/DMWrapperId.kt
+++ b/domain/src/main/java/com/example/domain/model/vo/dmwrapper/DMWrapperId.kt
@@ -1,0 +1,10 @@
+package com.example.domain.model.vo.dmwrapper
+
+import kotlin.jvm.JvmInline
+
+@JvmInline
+value class DMWrapperId(val value: String) {
+    init {
+        require(value.isNotBlank()) { "DMWrapperId cannot be blank." }
+    }
+}


### PR DESCRIPTION
This commit refactors the DMWrapper.kt entity to strictly follow the defined Domain-Driven Design rules.

Key changes include:
- Implemented the AggregateRoot interface, including domain event tracking.
- Made the primary constructor private and introduced a static factory method (`create`) for controlled instantiation.
- Wrapped the `dmChannelId` in a new `DMWrapperId` Value Object.
- Updated `otherUserId` to use the existing `DocumentId` Value Object.
- Introduced `DMWrapperCreatedEvent` and `DMWrapperOtherUserChangedEvent` to capture significant state changes.
- Added `createdAt` and `updatedAt` timestamp fields for lifecycle tracking.
- Ensured property declarations and state modification methods adhere to the specified refactoring rules, similar to `User.kt` and `Schedule.kt`.

These changes enhance type safety, encapsulate business logic, and improve the overall design of the DMWrapper entity within the domain layer.