### PR TITLE
Refactor Category.kt to align with DDD principles

### DIFF
--- a/domain/src/main/java/com/example/domain/event/category/CategoryCreatedEvent.kt
+++ b/domain/src/main/java/com/example/domain/event/category/CategoryCreatedEvent.kt
@@ -1,0 +1,15 @@
+package com.example.domain.event.category
+
+import com.example.domain.event.DomainEvent
+import java.time.Instant
+
+/**
+ * Raised when a new category is created.
+ *
+ * @param categoryId The identifier of the newly created category.
+ * @param occurredOn The time when the category was created.
+ */
+data class CategoryCreatedEvent(
+    val categoryId: String,
+    override val occurredOn: Instant = Instant.now()
+) : DomainEvent

--- a/domain/src/main/java/com/example/domain/event/category/CategoryNameChangedEvent.kt
+++ b/domain/src/main/java/com/example/domain/event/category/CategoryNameChangedEvent.kt
@@ -1,0 +1,15 @@
+package com.example.domain.event.category
+
+import com.example.domain.event.DomainEvent
+import java.time.Instant
+
+/**
+ * Raised when a category's name is changed.
+ *
+ * @param categoryId The identifier of the category whose name changed.
+ * @param occurredOn Timestamp when the event occurred.
+ */
+data class CategoryNameChangedEvent(
+    val categoryId: String,
+    override val occurredOn: Instant = Instant.now()
+) : DomainEvent

--- a/domain/src/main/java/com/example/domain/event/category/CategoryOrderChangedEvent.kt
+++ b/domain/src/main/java/com/example/domain/event/category/CategoryOrderChangedEvent.kt
@@ -1,0 +1,15 @@
+package com.example.domain.event.category
+
+import com.example.domain.event.DomainEvent
+import java.time.Instant
+
+/**
+ * Raised when a category's order is changed.
+ *
+ * @param categoryId The identifier of the category whose order changed.
+ * @param occurredOn Timestamp when the event occurred.
+ */
+data class CategoryOrderChangedEvent(
+    val categoryId: String,
+    override val occurredOn: Instant = Instant.now()
+) : DomainEvent

--- a/domain/src/main/java/com/example/domain/model/base/Category.kt
+++ b/domain/src/main/java/com/example/domain/model/base/Category.kt
@@ -1,16 +1,180 @@
 package com.example.domain.model.base
 
-import com.google.firebase.firestore.DocumentId
+import com.example.domain.event.AggregateRoot
+import com.example.domain.event.DomainEvent
+import com.example.domain.event.category.CategoryCreatedEvent // These will be defined in the next step
+import com.example.domain.event.category.CategoryNameChangedEvent // These will be defined in the next step
+import com.example.domain.event.category.CategoryOrderChangedEvent // These will be defined in the next step
+import com.example.domain.model.vo.DocumentId
+import com.example.domain.model.vo.category.CategoryId
+import com.example.domain.model.vo.category.CategoryName
+import com.example.domain.model.vo.category.CategoryOrder
+import com.example.domain.model.vo.category.IsCategoryFlag
 import java.time.Instant
 
-data class Category(
-    @DocumentId val id: String = "",
-    val name: String = "",
-    // 순서를 소수점으로 관리하면 정수보다 유연하게 아이템 사이에 삽입할 수 있습니다.
-    val order: Double = 0.0,
-    val createdBy: String = "",
-    val createdAt: Instant? = null,
-    val updatedAt: Instant? = null,
-    val isCategory: Boolean = true,
-)
+/**
+ * Represents a Category aggregate in the domain.
+ * A category is used to group channels or other items, typically within a project context.
+ * Its state changes are tracked via domain events.
+ *
+ * @property id The unique identifier of the category.
+ * @property name The name of the category. Mutable via [changeName].
+ * @property order The display order of the category. Mutable via [changeOrder].
+ * @property createdBy The identifier of the user/entity that created this category. Immutable.
+ * @property createdAt Timestamp of when the category was created. Immutable.
+ * @property updatedAt Timestamp of the last update to the category. Mutable.
+ * @property isCategory Flag indicating if this entity is a category (true by default). Immutable.
+ */
+class Category private constructor(
+    // Constructor parameters are intentionally without val/var
+    // and match the properties declared in the class body.
+    id: CategoryId,
+    name: CategoryName,
+    order: CategoryOrder,
+    createdBy: DocumentId,
+    createdAt: Instant,
+    updatedAt: Instant?,
+    isCategory: IsCategoryFlag
+) : AggregateRoot {
 
+    val id: CategoryId = id
+    var name: CategoryName = name
+        private set
+    var order: CategoryOrder = order
+        private set
+    val createdBy: DocumentId = createdBy
+    val createdAt: Instant = createdAt
+    var updatedAt: Instant? = updatedAt
+        private set
+    val isCategory: IsCategoryFlag = isCategory
+
+    private val _domainEvents: MutableList<DomainEvent> = mutableListOf()
+
+    /**
+     * Retrieves all domain events that have occurred since the last call and clears the list.
+     * @return A list of [DomainEvent] objects.
+     */
+    override fun pullDomainEvents(): List<DomainEvent> {
+        val events = _domainEvents.toList() // Make a copy
+        _domainEvents.clear()
+        return events
+    }
+
+    /**
+     * Clears all domain events currently held by the aggregate.
+     * Typically used by the event dispatcher after processing events.
+     */
+    override fun clearDomainEvents() {
+        _domainEvents.clear()
+    }
+
+    /**
+     * Changes the name of the category.
+     * If the new name is different from the current name, the `name` and `updatedAt` properties are updated,
+     * and a [CategoryNameChangedEvent] is raised.
+     *
+     * @param newName The new name for the category.
+     */
+    fun changeName(newName: CategoryName) {
+        if (this.name == newName) return // No change if the name is the same
+
+        this.name = newName
+        this.updatedAt = Instant.now()
+        _domainEvents.add(CategoryNameChangedEvent(this.id.value))
+    }
+
+    /**
+     * Changes the display order of the category.
+     * If the new order is different from the current order, the `order` and `updatedAt` properties are updated,
+     * and a [CategoryOrderChangedEvent] is raised.
+     *
+     * @param newOrder The new order for the category.
+     */
+    fun changeOrder(newOrder: CategoryOrder) {
+        if (this.order == newOrder) return // No change if the order is the same
+
+        this.order = newOrder
+        this.updatedAt = Instant.now()
+        _domainEvents.add(CategoryOrderChangedEvent(this.id.value))
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        other as Category
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id.hashCode()
+    }
+
+    companion object {
+        /**
+         * Creates a new Category instance.
+         * This factory method is the designated way to create new categories.
+         * It initializes the category's creation and update timestamps and raises a [CategoryCreatedEvent].
+         *
+         * @param id The unique identifier for the new category.
+         * @param name The initial name of the category.
+         * @param order The initial display order of the category.
+         * @param createdBy The identifier of the user/entity creating the category.
+         * @param isCategory Flag indicating if this is a category. Defaults to true.
+         * @return A new [Category] instance, ready to be persisted.
+         */
+        fun create(
+            id: CategoryId,
+            name: CategoryName,
+            order: CategoryOrder,
+            createdBy: DocumentId,
+            isCategory: IsCategoryFlag = IsCategoryFlag(true)
+        ): Category {
+            val now = Instant.now()
+            val category = Category(
+                id = id,
+                name = name,
+                order = order,
+                createdBy = createdBy,
+                createdAt = now,
+                updatedAt = now,
+                isCategory = isCategory
+            )
+            category._domainEvents.add(CategoryCreatedEvent(id.value))
+            return category
+        }
+
+        /**
+         * Reconstructs a Category instance from a data source (e.g., when loading from a database).
+         * This method assumes the data is valid as it's coming from a trusted source.
+         * No domain events are raised during reconstruction.
+         *
+         * @param id The category's identifier.
+         * @param name The category's name.
+         * @param order The category's display order.
+         * @param createdBy Identifier of the creating user/entity.
+         * @param createdAt Timestamp of creation.
+         * @param updatedAt Timestamp of the last update, can be null if never updated post-creation.
+         * @param isCategory Flag indicating if this is a category.
+         * @return An instance of [Category] populated with data source values.
+         */
+        fun fromDataSource(
+            id: CategoryId,
+            name: CategoryName,
+            order: CategoryOrder,
+            createdBy: DocumentId,
+            createdAt: Instant,
+            updatedAt: Instant?,
+            isCategory: IsCategoryFlag
+        ): Category {
+            return Category(
+                id = id,
+                name = name,
+                order = order,
+                createdBy = createdBy,
+                createdAt = createdAt,
+                updatedAt = updatedAt,
+                isCategory = isCategory
+            )
+        }
+    }
+}

--- a/domain/src/main/java/com/example/domain/model/vo/category/CategoryId.kt
+++ b/domain/src/main/java/com/example/domain/model/vo/category/CategoryId.kt
@@ -1,0 +1,17 @@
+package com.example.domain.model.vo.category
+
+import kotlin.jvm.JvmInline
+
+/**
+ * Represents the unique identifier for a Category.
+ */
+@JvmInline
+value class CategoryId(val value: String) {
+    init {
+        require(value.isNotBlank()) { "CategoryId는 비어있을 수 없습니다." }
+        // Assuming a similar max length as DocumentId for consistency, if not specified.
+        // Or remove if no specific length constraint for CategoryId itself beyond DocumentId's general use.
+        // For now, let's use a common practice for IDs.
+        require(value.length <= 128) { "CategoryId는 128자를 초과할 수 없습니다." }
+    }
+}

--- a/domain/src/main/java/com/example/domain/model/vo/category/CategoryName.kt
+++ b/domain/src/main/java/com/example/domain/model/vo/category/CategoryName.kt
@@ -1,0 +1,14 @@
+package com.example.domain.model.vo.category
+
+import kotlin.jvm.JvmInline
+
+/**
+ * Represents the name of a Category.
+ */
+@JvmInline
+value class CategoryName(val value: String) {
+    init {
+        require(value.isNotBlank()) { "CategoryName은 비어있을 수 없습니다." }
+        require(value.length <= 100) { "CategoryName은 100자를 초과할 수 없습니다." }
+    }
+}

--- a/domain/src/main/java/com/example/domain/model/vo/category/CategoryOrder.kt
+++ b/domain/src/main/java/com/example/domain/model/vo/category/CategoryOrder.kt
@@ -1,0 +1,12 @@
+package com.example.domain.model.vo.category
+
+import kotlin.jvm.JvmInline
+
+/**
+ * Represents the display order of a Category.
+ */
+@JvmInline
+value class CategoryOrder(val value: Double) {
+    // No specific validation for Double mentioned in prompt, keeping it simple.
+    // init { require(value >= 0) { "CategoryOrder는 음수일 수 없습니다." } } // Example if needed
+}

--- a/domain/src/main/java/com/example/domain/model/vo/category/IsCategoryFlag.kt
+++ b/domain/src/main/java/com/example/domain/model/vo/category/IsCategoryFlag.kt
@@ -1,0 +1,11 @@
+package com.example.domain.model.vo.category
+
+import kotlin.jvm.JvmInline
+
+/**
+ * Flag indicating if the item is a Category (true) or another type (e.g., a channel, false).
+ * In the original Category.kt, this was 'isCategory: Boolean = true'.
+ * This VO wraps this boolean flag.
+ */
+@JvmInline
+value class IsCategoryFlag(val value: Boolean)


### PR DESCRIPTION
This commit refactors the Category.kt entity to be an AggregateRoot, adhering to the project's Domain-Driven Design guidelines and refactoring rules.

Key changes include:
- Category.kt now implements the AggregateRoot interface.
- The primary constructor is private, with object creation handled by `create()` and `fromDataSource()` factory methods in the companion object.
- Properties are defined in the class body, using `val` for immutable fields and `var` with `private set` for mutable ones.
- Primitive types representing domain concepts (id, name, order, isCategory flag) are wrapped in specific Value Objects (CategoryId, CategoryName, CategoryOrder, IsCategoryFlag) residing in `domain/model/vo/category/`. The `createdBy` field uses the existing `DocumentId` VO.
- State changes are managed through public methods (e.g., `changeName`, `changeOrder`), which now generate and collect domain events.
- New domain event classes (CategoryCreatedEvent, CategoryNameChangedEvent, CategoryOrderChangedEvent) have been added in `domain/event/category/`. These events follow the existing pattern of carrying the aggregate's String ID.
- KDoc comments have been added to Category.kt and the new VOs and event classes.

These changes ensure Category.kt is consistent with other domain entities like User.kt and Schedule.kt, improving type safety, encapsulation, and adherence to DDD best practices.