### PR TITLE
Refactor Friend entity to align with DDD principles

### DIFF
--- a/domain/src/main/java/com/example/domain/event/friend/FriendCreatedEvent.kt
+++ b/domain/src/main/java/com/example/domain/event/friend/FriendCreatedEvent.kt
@@ -1,0 +1,10 @@
+package com.example.domain.event.friend
+
+import com.example.domain.event.DomainEvent
+import com.example.domain.model.vo.friend.FriendId
+import java.time.Instant
+
+data class FriendCreatedEvent(
+    val friendId: FriendId,
+    override val occurredOn: Instant = Instant.now()
+) : DomainEvent

--- a/domain/src/main/java/com/example/domain/event/friend/FriendNameChangedEvent.kt
+++ b/domain/src/main/java/com/example/domain/event/friend/FriendNameChangedEvent.kt
@@ -1,0 +1,12 @@
+package com.example.domain.event.friend
+
+import com.example.domain.event.DomainEvent
+import com.example.domain.model.vo.friend.FriendId
+import com.example.domain.model.vo.friend.FriendName
+import java.time.Instant
+
+data class FriendNameChangedEvent(
+    val friendId: FriendId,
+    val newName: FriendName,
+    override val occurredOn: Instant = Instant.now()
+) : DomainEvent

--- a/domain/src/main/java/com/example/domain/event/friend/FriendProfileImageChangedEvent.kt
+++ b/domain/src/main/java/com/example/domain/event/friend/FriendProfileImageChangedEvent.kt
@@ -1,0 +1,12 @@
+package com.example.domain.event.friend
+
+import com.example.domain.event.DomainEvent
+import com.example.domain.model.vo.friend.FriendId
+import com.example.domain.model.vo.friend.FriendProfileImageUrl
+import java.time.Instant
+
+data class FriendProfileImageChangedEvent(
+    val friendId: FriendId,
+    val newProfileImageUrl: FriendProfileImageUrl?, // Can be null if image is removed
+    override val occurredOn: Instant = Instant.now()
+) : DomainEvent

--- a/domain/src/main/java/com/example/domain/event/friend/FriendStatusChangedEvent.kt
+++ b/domain/src/main/java/com/example/domain/event/friend/FriendStatusChangedEvent.kt
@@ -1,0 +1,12 @@
+package com.example.domain.event.friend
+
+import com.example.domain.event.DomainEvent
+import com.example.domain.model.enum.FriendStatus
+import com.example.domain.model.vo.friend.FriendId
+import java.time.Instant
+
+data class FriendStatusChangedEvent(
+    val friendId: FriendId,
+    val newStatus: FriendStatus,
+    override val occurredOn: Instant = Instant.now()
+) : DomainEvent

--- a/domain/src/main/java/com/example/domain/model/base/Friend.kt
+++ b/domain/src/main/java/com/example/domain/model/base/Friend.kt
@@ -1,16 +1,208 @@
 package com.example.domain.model.base
 
+import com.example.domain.event.AggregateRoot
+import com.example.domain.event.DomainEvent
+import com.example.domain.event.friend.FriendCreatedEvent
+import com.example.domain.event.friend.FriendNameChangedEvent
+import com.example.domain.event.friend.FriendProfileImageChangedEvent
+import com.example.domain.event.friend.FriendStatusChangedEvent
 import com.example.domain.model.enum.FriendStatus
-import com.google.firebase.firestore.DocumentId
+import com.example.domain.model.vo.friend.FriendId
+import com.example.domain.model.vo.friend.FriendName
+import com.example.domain.model.vo.friend.FriendProfileImageUrl
 import java.time.Instant
 
-data class Friend(
-    @DocumentId val friendUid: String = "",
-    val friendName: String = "",
-    val friendProfileImageUrl: String? = null,
-    // "requested", "accepted", "pending", "blocked"
-    val status: FriendStatus = FriendStatus.PENDING,
-    val requestedAt: Instant? = null,
-    val acceptedAt: Instant? = null
-)
+class Friend private constructor(
+    // Immutable properties
+    id: FriendId,
+    requestedAt: Instant?, // This could be when the friend request was sent by the current user or received
+    acceptedAt: Instant?,  // This could be when the friend request was accepted
 
+    // Mutable properties
+    name: FriendName,
+    profileImageUrl: FriendProfileImageUrl?,
+    status: FriendStatus,
+    createdAt: Instant,
+    updatedAt: Instant
+
+) : AggregateRoot {
+
+    val id: FriendId = id
+    val requestedAt: Instant? = requestedAt
+    var acceptedAt: Instant? = acceptedAt // Made var in case it needs to be set by a method
+        private set
+
+    var name: FriendName = name
+        private set
+
+    var profileImageUrl: FriendProfileImageUrl? = profileImageUrl
+        private set
+
+    var status: FriendStatus = status
+        private set
+
+    val createdAt: Instant = createdAt
+    var updatedAt: Instant = updatedAt
+        private set
+
+    private val _domainEvents: MutableList<DomainEvent> = mutableListOf()
+
+    override fun pullDomainEvents(): List<DomainEvent> {
+        val events = _domainEvents.toList()
+        _domainEvents.clear()
+        return events
+    }
+
+    override fun clearDomainEvents() {
+        _domainEvents.clear()
+    }
+
+    // --- Business Methods ---
+
+    fun changeName(newName: FriendName) {
+        if (this.name == newName) return
+        this.name = newName
+        this.updatedAt = Instant.now()
+        _domainEvents.add(FriendNameChangedEvent(this.id, newName))
+    }
+
+    fun changeProfileImage(newProfileImageUrl: FriendProfileImageUrl?) {
+        if (this.profileImageUrl == newProfileImageUrl) return
+        this.profileImageUrl = newProfileImageUrl
+        this.updatedAt = Instant.now()
+        _domainEvents.add(FriendProfileImageChangedEvent(this.id, newProfileImageUrl))
+    }
+
+    fun acceptRequest() {
+        if (this.status == FriendStatus.PENDING || this.status == FriendStatus.REQUESTED) {
+            this.status = FriendStatus.ACCEPTED
+            this.acceptedAt = Instant.now()
+            this.updatedAt = Instant.now()
+            _domainEvents.add(FriendStatusChangedEvent(this.id, this.status))
+        }
+        // Consider if any action/event is needed if status is not PENDING/REQUESTED
+    }
+
+    fun blockUser() {
+        if (this.status == FriendStatus.BLOCKED) return
+        this.status = FriendStatus.BLOCKED
+        // acceptedAt might be nulled out or kept depending on business rule
+        this.updatedAt = Instant.now()
+        _domainEvents.add(FriendStatusChangedEvent(this.id, this.status))
+    }
+
+    fun removeFriend() {
+        // This is a conceptual removal. Depending on the system,
+        // it might mean setting status to BLOCKED, or a new "REMOVED" status,
+        // or even actual deletion which is a repository concern.
+        // For now, let's assume it means blocking or changing to a non-interactive status.
+        // If actual deletion is implied, this method might not belong here, or should trigger a specific event.
+        if (this.status == FriendStatus.BLOCKED && this.name.value == "Unknown") return // Example: already in a removed-like state
+
+        // For this example, let's change status to BLOCKED and clear personal info
+        // This is a placeholder for a more defined "removed" state or process
+        this.status = FriendStatus.BLOCKED // Or a new FriendStatus.REMOVED
+        // this.name = FriendName("Unknown") // Masking name might be a policy
+        // this.profileImageUrl = null
+        this.updatedAt = Instant.now()
+        _domainEvents.add(FriendStatusChangedEvent(this.id, this.status))
+    }
+
+    fun markAsPending() {
+        if (this.status == FriendStatus.PENDING) return
+        this.status = FriendStatus.PENDING
+        this.updatedAt = Instant.now()
+        _domainEvents.add(FriendStatusChangedEvent(this.id, this.status))
+    }
+
+    fun markAsRequested() {
+        // This status might be used if the current user sent the request
+        if (this.status == FriendStatus.REQUESTED) return
+        this.status = FriendStatus.REQUESTED
+        this.updatedAt = Instant.now()
+        _domainEvents.add(FriendStatusChangedEvent(this.id, this.status))
+    }
+
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        other as Friend
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id.hashCode()
+    }
+
+    companion object {
+        fun newRequest(
+            id: FriendId,
+            name: FriendName,
+            profileImageUrl: FriendProfileImageUrl?,
+            requestedAt: Instant // Time the request is made
+        ): Friend {
+            val now = Instant.now()
+            val friend = Friend(
+                id = id,
+                name = name,
+                profileImageUrl = profileImageUrl,
+                status = FriendStatus.REQUESTED, // Current user sent the request
+                requestedAt = requestedAt,
+                acceptedAt = null,
+                createdAt = now,
+                updatedAt = now
+            )
+            friend._domainEvents.add(FriendCreatedEvent(id))
+            // Optionally, add a FriendStatusChangedEvent if REQUESTED is considered a status change from an initial null state
+            // friend._domainEvents.add(FriendStatusChangedEvent(id, FriendStatus.REQUESTED))
+            return friend
+        }
+
+        fun receivedRequest(
+            id: FriendId,
+            name: FriendName,
+            profileImageUrl: FriendProfileImageUrl?,
+            requestedAt: Instant // Time the request was received
+        ): Friend {
+            val now = Instant.now()
+            val friend = Friend(
+                id = id,
+                name = name,
+                profileImageUrl = profileImageUrl,
+                status = FriendStatus.PENDING, // Current user received the request, it's pending their action
+                requestedAt = requestedAt,
+                acceptedAt = null,
+                createdAt = now,
+                updatedAt = now
+            )
+            friend._domainEvents.add(FriendCreatedEvent(id))
+            // friend._domainEvents.add(FriendStatusChangedEvent(id, FriendStatus.PENDING))
+            return friend
+        }
+
+        // Factory method for reconstructing from data source
+        fun fromDataSource(
+            id: FriendId,
+            name: FriendName,
+            profileImageUrl: FriendProfileImageUrl?,
+            status: FriendStatus,
+            requestedAt: Instant?,
+            acceptedAt: Instant?,
+            createdAt: Instant,
+            updatedAt: Instant
+        ): Friend {
+            return Friend(
+                id = id,
+                name = name,
+                profileImageUrl = profileImageUrl,
+                status = status,
+                requestedAt = requestedAt,
+                acceptedAt = acceptedAt,
+                createdAt = createdAt,
+                updatedAt = updatedAt
+            )
+            // No domain event on reconstruction from data source usually, unless specific logic dictates it.
+        }
+    }
+}

--- a/domain/src/main/java/com/example/domain/model/vo/friend/FriendId.kt
+++ b/domain/src/main/java/com/example/domain/model/vo/friend/FriendId.kt
@@ -1,0 +1,10 @@
+package com.example.domain.model.vo.friend
+
+import kotlin.jvm.JvmInline
+
+@JvmInline
+value class FriendId(val value: String) {
+    init {
+        require(value.isNotBlank()) { "Friend ID는 비어있을 수 없습니다." }
+    }
+}

--- a/domain/src/main/java/com/example/domain/model/vo/friend/FriendName.kt
+++ b/domain/src/main/java/com/example/domain/model/vo/friend/FriendName.kt
@@ -1,0 +1,11 @@
+package com.example.domain.model.vo.friend
+
+import kotlin.jvm.JvmInline
+
+@JvmInline
+value class FriendName(val value: String) {
+    init {
+        // Add any validation if necessary, e.g., length constraints
+        require(value.isNotBlank()) { "Friend 이름은 비어있을 수 없습니다." }
+    }
+}

--- a/domain/src/main/java/com/example/domain/model/vo/friend/FriendProfileImageUrl.kt
+++ b/domain/src/main/java/com/example/domain/model/vo/friend/FriendProfileImageUrl.kt
@@ -1,0 +1,8 @@
+package com.example.domain.model.vo.friend
+
+import kotlin.jvm.JvmInline
+
+// Assuming URL can be empty or null if no image, so no isNotBlank check here.
+// Specific URL validation can be added if required.
+@JvmInline
+value class FriendProfileImageUrl(val value: String)


### PR DESCRIPTION
This commit refactors the `Friend.kt` domain entity based on the provided Domain-Driven Design (DDD) documentation and refactoring guidelines.

Key changes include:
- Implemented the `AggregateRoot` interface.
- Made the primary constructor private and introduced factory methods (`newRequest`, `receivedRequest`, `fromDataSource`) in a companion object for controlled instantiation.
- Wrapped primitive type properties with semantic meaning into new Value Objects (VOs):
    - `FriendId` for `friendUid`
    - `FriendName` for `friendName`
    - `FriendProfileImageUrl` for `friendProfileImageUrl`
- Introduced `createdAt` and `updatedAt` timestamps for tracking.
- Implemented domain event generation for state changes. New event classes created:
    - `FriendCreatedEvent`
    - `FriendNameChangedEvent`
    - `FriendProfileImageChangedEvent`
    - `FriendStatusChangedEvent`
- State modification is now exclusively handled through public methods (e.g., `changeName`, `acceptRequest`, `blockUser`), which also trigger the relevant domain events.
- Ensured consistency with the structure of existing entities like `User.kt` and `Schedule.kt`.
- Removed Firebase-specific annotations like `@DocumentId` from the domain entity.

These changes enhance type safety, clarify the Friend aggregate's responsibilities, and make its state transitions more explicit through domain events, improving the overall robustness and maintainability of the domain model.