### PR TITLE
Refactor Invite.kt to align with DDD principles

### DIFF
--- a/domain/src/main/java/com/example/domain/event/AggregateRoot.kt
+++ b/domain/src/main/java/com/example/domain/event/AggregateRoot.kt
@@ -1,0 +1,6 @@
+package com.example.domain.event
+
+interface AggregateRoot {
+    fun pullDomainEvents(): List<DomainEvent>
+    fun clearDomainEvents() // Added this based on User.kt
+}

--- a/domain/src/main/java/com/example/domain/event/DomainEvent.kt
+++ b/domain/src/main/java/com/example/domain/event/DomainEvent.kt
@@ -1,0 +1,7 @@
+package com.example.domain.event
+
+import java.time.Instant
+
+interface DomainEvent {
+    val occurredOn: Instant
+}

--- a/domain/src/main/java/com/example/domain/event/invite/InviteCreatedEvent.kt
+++ b/domain/src/main/java/com/example/domain/event/invite/InviteCreatedEvent.kt
@@ -1,0 +1,15 @@
+package com.example.domain.event.invite
+
+import com.example.domain.event.DomainEvent
+import com.example.domain.model.enum.InviteStatus
+import com.example.domain.model.vo.DocumentId
+import com.example.domain.model.vo.invite.InviteId
+import java.time.Instant
+
+data class InviteCreatedEvent(
+    val inviteId: InviteId,
+    val createdBy: DocumentId,
+    val initialStatus: InviteStatus,
+    val expiresAt: Instant?,
+    override val occurredOn: Instant = Instant.now()
+) : DomainEvent

--- a/domain/src/main/java/com/example/domain/event/invite/InviteExpiredEvent.kt
+++ b/domain/src/main/java/com/example/domain/event/invite/InviteExpiredEvent.kt
@@ -1,0 +1,10 @@
+package com.example.domain.event.invite
+
+import com.example.domain.event.DomainEvent
+import com.example.domain.model.vo.invite.InviteId
+import java.time.Instant
+
+data class InviteExpiredEvent(
+    val inviteId: InviteId,
+    override val occurredOn: Instant = Instant.now()
+) : DomainEvent

--- a/domain/src/main/java/com/example/domain/event/invite/InviteStatusChangedEvent.kt
+++ b/domain/src/main/java/com/example/domain/event/invite/InviteStatusChangedEvent.kt
@@ -1,0 +1,13 @@
+package com.example.domain.event.invite
+
+import com.example.domain.event.DomainEvent
+import com.example.domain.model.enum.InviteStatus
+import com.example.domain.model.vo.invite.InviteId
+import java.time.Instant
+
+data class InviteStatusChangedEvent(
+    val inviteId: InviteId,
+    val newStatus: InviteStatus,
+    val oldStatus: InviteStatus, // It's often useful to know the previous state
+    override val occurredOn: Instant = Instant.now()
+) : DomainEvent

--- a/domain/src/main/java/com/example/domain/model/base/Invite.kt
+++ b/domain/src/main/java/com/example/domain/model/base/Invite.kt
@@ -1,17 +1,140 @@
 package com.example.domain.model.base
 
-import com.example.domain.model._new.enum.InviteStatus
-import com.google.firebase.Timestamp
-import com.google.firebase.firestore.DocumentId
-import com.google.firebase.firestore.ServerTimestamp
+import com.example.domain.event.AggregateRoot
+import com.example.domain.event.DomainEvent
+import com.example.domain.event.invite.InviteCreatedEvent
+import com.example.domain.event.invite.InviteExpiredEvent
+import com.example.domain.event.invite.InviteStatusChangedEvent
+import com.example.domain.model.enum.InviteStatus // Keep existing import for now, will be com.example.domain.model.enum.InviteStatus
+import com.example.domain.model.vo.DocumentId // For createdBy
+import com.example.domain.model.vo.invite.InviteCode
+import com.example.domain.model.vo.invite.InviteId
 import java.time.Instant
 
-data class Invite(
-    @DocumentId val id: String = "",
-    val inviteCode: String = "", // 고유한 초대 코드
-    val status: InviteStatus = InviteStatus.ACTIVE, // "ACTIVE", "INACTIVE", "EXPIRED"
-    val createdBy: String = "", // 초대를 생성한 사용자의 ID
-    val createdAt: Instant? = null,
-    val expiresAt: Instant? = null // 만료 시간 (null이면 무제한)
-)
+class Invite private constructor(
+    id: InviteId,
+    inviteCode: InviteCode,
+    status: InviteStatus,
+    createdBy: DocumentId,
+    createdAt: Instant,
+    updatedAt: Instant,
+    expiresAt: Instant?
+) : AggregateRoot {
 
+    // Immutable properties
+    val id: InviteId = id
+    val inviteCode: InviteCode = inviteCode
+    val createdBy: DocumentId = createdBy
+    val createdAt: Instant = createdAt
+    val expiresAt: Instant? = expiresAt
+
+    // Mutable properties
+    var status: InviteStatus = status
+        private set
+
+    var updatedAt: Instant = updatedAt
+        private set
+
+    private val _domainEvents: MutableList<DomainEvent> = mutableListOf()
+
+    override fun pullDomainEvents(): List<DomainEvent> {
+        val events = _domainEvents.toList()
+        _domainEvents.clear()
+        return events
+    }
+
+    override fun clearDomainEvents() {
+        _domainEvents.clear()
+    }
+
+    // Business logic methods for state changes will be added in a later step
+    // (e.g., changeStatus, expire)
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        other as Invite
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id.hashCode()
+    }
+
+    // Add new methods here:
+    fun changeStatus(newStatus: InviteStatus) {
+        if (this.status == newStatus) return // No change if status is the same
+        val oldStatus = this.status // Capture old status before changing
+        if (this.status == InviteStatus.EXPIRED && newStatus != InviteStatus.EXPIRED) {
+            // Potentially disallow changing status away from EXPIRED, depending on business rules
+            // For now, let's assume it's possible but log an event.
+        }
+
+        this.status = newStatus
+        this.updatedAt = Instant.now()
+        _domainEvents.add(InviteStatusChangedEvent(this.id, newStatus, oldStatus, this.updatedAt))
+    }
+
+    fun expire() {
+        if (this.status == InviteStatus.EXPIRED) return // Already expired
+
+        this.status = InviteStatus.EXPIRED
+        this.updatedAt = Instant.now()
+        _domainEvents.add(InviteExpiredEvent(this.id, this.updatedAt))
+    }
+
+    // Method to check if invite is still valid (not expired and active)
+    fun isActive(): Boolean {
+        val now = Instant.now()
+        return this.status == InviteStatus.ACTIVE && (this.expiresAt == null || this.expiresAt.isAfter(now))
+    }
+
+
+    companion object {
+        fun create(
+            id: InviteId,
+            inviteCode: InviteCode,
+            createdBy: DocumentId,
+            expiresAt: Instant? // Optional expiration
+        ): Invite {
+            val now = Instant.now()
+            var initialStatus = InviteStatus.ACTIVE
+            if (expiresAt != null && expiresAt.isBefore(now)) {
+                initialStatus = InviteStatus.EXPIRED
+            }
+
+            val invite = Invite(
+                id = id,
+                inviteCode = inviteCode,
+                status = initialStatus,
+                createdBy = createdBy,
+                createdAt = now,
+                updatedAt = now,
+                expiresAt = expiresAt
+            )
+            invite._domainEvents.add(InviteCreatedEvent(invite.id, invite.createdBy, invite.status, invite.expiresAt, invite.createdAt)) // Use invite.createdAt for occurredOn consistency
+            return invite
+        }
+
+        // Factory method for reconstituting from data source
+        fun fromDataSource(
+            id: InviteId,
+            inviteCode: InviteCode,
+            status: InviteStatus,
+            createdBy: DocumentId,
+            createdAt: Instant,
+            updatedAt: Instant,
+            expiresAt: Instant?
+        ): Invite {
+            return Invite(
+                id = id,
+                inviteCode = inviteCode,
+                status = status,
+                createdBy = createdBy,
+                createdAt = createdAt,
+                updatedAt = updatedAt,
+                expiresAt = expiresAt
+            )
+        }
+    }
+}

--- a/domain/src/main/java/com/example/domain/model/vo/invite/InviteCode.kt
+++ b/domain/src/main/java/com/example/domain/model/vo/invite/InviteCode.kt
@@ -1,0 +1,10 @@
+package com.example.domain.model.vo.invite
+
+@JvmInline
+value class InviteCode(val value: String) {
+    init {
+        // Example validation: Ensure invite code has a specific length or format if necessary
+        require(value.isNotBlank()) { "Invite code cannot be blank." }
+        // require(value.length == 8) { "Invite code must be 8 characters long." } // Example
+    }
+}

--- a/domain/src/main/java/com/example/domain/model/vo/invite/InviteId.kt
+++ b/domain/src/main/java/com/example/domain/model/vo/invite/InviteId.kt
@@ -1,0 +1,10 @@
+package com.example.domain.model.vo.invite
+
+import com.example.domain.model.vo.DocumentId // Assuming DocumentId is a suitable wrapper for generic IDs
+
+@JvmInline
+value class InviteId(val value: String) {
+    init {
+        require(value.isNotBlank()) { "Invite ID cannot be blank." }
+    }
+}


### PR DESCRIPTION
This commit refactors the Invite.kt domain entity to strictly adhere to the project's Domain-Driven Design (DDD) guidelines, ensuring consistency with other entities like User.kt and Schedule.kt.

Key changes include:
- Transformed Invite from a data class to a full AggregateRoot.
- Introduced private constructor and factory methods (`create`, `fromDataSource`) for controlled instantiation.
- Implemented domain event tracking (`_domainEvents`, `pullDomainEvents`, `clearDomainEvents`).
- Defined and integrated specific domain events:
    - InviteCreatedEvent
    - InviteStatusChangedEvent
    - InviteExpiredEvent
- Created Value Objects for Invite properties:
    - InviteId (for `id`)
    - InviteCode (for `inviteCode`)
- Ensured `createdBy` uses the common `DocumentId` Value Object.
- Added an `updatedAt` timestamp, managed by state-changing methods.
- State changes (`changeStatus`, `expire`) are now explicit methods that raise domain events.
- Removed direct dependencies on Firebase/Firestore from the domain entity.
- Ensured `InviteStatus.kt` enum is correctly located and referenced.
- Added `equals()` and `hashCode()` methods based on `InviteId`.

These changes enhance the robustness, testability, and maintainability of the Invite domain model by encapsulating business logic and state management within the entity itself, and by clearly defining its interactions through value objects and domain events.