### PR TITLE
Refactor HomeViewModel services creation

### DIFF
--- a/feature/feature_home/src/main/java/com/example/feature_home/ui/HomeScreen.kt
+++ b/feature/feature_home/src/main/java/com/example/feature_home/ui/HomeScreen.kt
@@ -315,8 +315,10 @@ fun HomeScreenInScaffoldPreview() {
                 }
             },
             floatingActionButtonPosition = FabPosition.End
-        ){
+        ) { innerPadding ->
+            Box(modifier = Modifier.padding(innerPadding)) {
 
+            }
         }
     }
 }

--- a/feature/feature_home/src/main/java/com/example/feature_home/viewmodel/service/CategoryManagementService.kt
+++ b/feature/feature_home/src/main/java/com/example/feature_home/viewmodel/service/CategoryManagementService.kt
@@ -5,29 +5,19 @@ import com.example.core_common.result.CustomResult
 import com.example.domain.model.base.Category
 import com.example.domain.model.base.ProjectChannel
 import com.example.domain.model.vo.DocumentId
-import com.example.domain.provider.project.ProjectStructureUseCaseProvider
 import com.example.domain.provider.project.ProjectStructureUseCases
-import javax.inject.Inject
 
 /**
  * 카테고리 상태 관리를 담당하는 Service
  * Domain UseCase들을 조합하여 카테고리 관련 기능을 제공합니다.
  */
-class CategoryManagementService @Inject constructor(
-    private val projectStructureUseCaseProvider: ProjectStructureUseCaseProvider
+class CategoryManagementService(
+    private val projectStructureUseCases: ProjectStructureUseCases
 ) {
-    
-    private lateinit var projectStructureUseCases: ProjectStructureUseCases
     
     // 카테고리 확장 상태 캐시 (프로젝트 ID -> 카테고리 ID -> 확장 상태)
     private val categoryExpandedStates = mutableMapOf<String, MutableMap<String, Boolean>>()
     
-    /**
-     * 특정 프로젝트를 위한 UseCase 초기화
-     */
-    fun initializeForProject(projectId: DocumentId) {
-        projectStructureUseCases = projectStructureUseCaseProvider.createForProject(projectId)
-    }
     
     /**
      * 카테고리 확장 상태를 토글
@@ -97,13 +87,8 @@ class CategoryManagementService @Inject constructor(
         Log.d("CategoryManagementService", "Reordering categories for project: $projectId")
         
         return try {
-            if (!::projectStructureUseCases.isInitialized) {
-                Log.w("CategoryManagementService", "ProjectStructureUseCases not initialized")
-                CustomResult.Failure(IllegalStateException("Service not initialized"))
-            } else {
-                val categoryIds = reorderedCategories.map { it.id.value }
-                projectStructureUseCases.reorderCategoriesUseCase(projectId, categoryIds)
-            }
+            val categoryIds = reorderedCategories.map { it.id.value }
+            projectStructureUseCases.reorderCategoriesUseCase(projectId, categoryIds)
         } catch (e: Exception) {
             Log.e("CategoryManagementService", "Failed to reorder categories", e)
             CustomResult.Failure(e)
@@ -121,13 +106,8 @@ class CategoryManagementService @Inject constructor(
         Log.d("CategoryManagementService", "Reordering channels for project: $projectId, category: $categoryId")
         
         return try {
-            if (!::projectStructureUseCases.isInitialized) {
-                Log.w("CategoryManagementService", "ProjectStructureUseCases not initialized")
-                CustomResult.Failure(IllegalStateException("Service not initialized"))
-            } else {
-                val channelIds = reorderedChannels.map { it.id.value }
-                projectStructureUseCases.reorderChannelsUseCase(projectId, categoryId, channelIds)
-            }
+            val channelIds = reorderedChannels.map { it.id.value }
+            projectStructureUseCases.reorderChannelsUseCase(projectId, categoryId, channelIds)
         } catch (e: Exception) {
             Log.e("CategoryManagementService", "Failed to reorder channels", e)
             CustomResult.Failure(e)

--- a/feature/feature_home/src/main/java/com/example/feature_home/viewmodel/service/LoadDmsService.kt
+++ b/feature/feature_home/src/main/java/com/example/feature_home/viewmodel/service/LoadDmsService.kt
@@ -3,38 +3,23 @@ package com.example.feature_home.viewmodel.service
 import android.util.Log
 import com.example.core_common.result.CustomResult
 import com.example.domain.model.base.DMWrapper
-import com.example.domain.model.vo.UserId
-import com.example.domain.provider.dm.DMUseCaseProvider
 import com.example.domain.provider.dm.DMUseCases
-import com.example.domain.provider.user.UserUseCaseProvider
 import com.example.domain.provider.user.UserUseCases
 import com.example.feature_home.model.DmUiModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
-import javax.inject.Inject
 
 /**
  * DM 데이터 로딩을 담당하는 Service
  * Domain UseCase들을 조합하여 UI에 특화된 DM 데이터를 제공합니다.
  */
-class LoadDmsService @Inject constructor(
-    private val dmUseCaseProvider: DMUseCaseProvider,
-    private val userUseCaseProvider: UserUseCaseProvider
+class LoadDmsService(
+    private val dmUseCases: DMUseCases,
+    private val userUseCases: UserUseCases
 ) {
-    
-    private val userUseCases: UserUseCases = userUseCaseProvider.createForUser()
-    private lateinit var dmUseCases: DMUseCases
-    
-    /**
-     * 특정 사용자를 위한 DM UseCase 초기화
-     */
-    fun initializeForUser(userId: UserId) {
-        dmUseCases = dmUseCaseProvider.createForUser(userId)
-    }
     
     /**
      * DMWrapper 객체를 UI에 최적화된 DmUiModel로 변환
@@ -68,12 +53,6 @@ class LoadDmsService @Inject constructor(
                     if (currentUser.id.value.isEmpty()) {
                         Log.w("LoadDmsService", "Current user ID is empty - clearing DMs")
                         emit(CustomResult.Success(emptyList()))
-                        return@flow
-                    }
-                    
-                    if (!::dmUseCases.isInitialized) {
-                        Log.w("LoadDmsService", "DM UseCases not initialized")
-                        emit(CustomResult.Failure(IllegalStateException("DM UseCases not initialized")))
                         return@flow
                     }
                     

--- a/feature/feature_home/src/main/java/com/example/feature_home/viewmodel/service/LoadProjectsService.kt
+++ b/feature/feature_home/src/main/java/com/example/feature_home/viewmodel/service/LoadProjectsService.kt
@@ -2,33 +2,27 @@ package com.example.feature_home.viewmodel.service
 
 import android.util.Log
 import com.example.core_common.result.CustomResult
-import com.example.domain.provider.project.CoreProjectUseCaseProvider
 import com.example.domain.provider.project.CoreProjectUseCases
 import com.example.feature_home.model.ProjectUiModel
 import com.example.feature_home.model.toProjectUiModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.map
-import javax.inject.Inject
 
 /**
  * 프로젝트 데이터 로딩을 담당하는 Service
  * Domain UseCase들을 조합하여 UI에 특화된 프로젝트 데이터를 제공합니다.
  */
-class LoadProjectsService @Inject constructor(
-    private val coreProjectUseCaseProvider: CoreProjectUseCaseProvider
+class LoadProjectsService(
+    private val coreProjectUseCases: CoreProjectUseCases
 ) {
-    
-    private lateinit var coreProjectUseCases: CoreProjectUseCases
 
     /**
      * 사용자가 참여한 프로젝트 목록을 UI에 최적화된 형태로 스트림 제공
      */
     fun getUserParticipatingProjectsStream(): Flow<CustomResult<List<ProjectUiModel>, Exception>> = flow {
         Log.d("LoadProjectsService", "Starting to load projects")
-        coreProjectUseCases = coreProjectUseCaseProvider.createForCurrentUser()
 
         try {
             emitAll(

--- a/feature/feature_home/src/main/java/com/example/feature_home/viewmodel/service/LoadUserDataService.kt
+++ b/feature/feature_home/src/main/java/com/example/feature_home/viewmodel/service/LoadUserDataService.kt
@@ -4,24 +4,20 @@ import android.util.Log
 import com.example.core_common.result.CustomResult
 import com.example.domain.model.base.User
 import com.example.domain.model.vo.UserId
-import com.example.domain.provider.user.UserUseCaseProvider
 import com.example.domain.provider.user.UserUseCases
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
-import javax.inject.Inject
 
 /**
  * 사용자 데이터 로딩을 담당하는 Service
  * Domain UseCase들을 조합하여 UI에 특화된 사용자 데이터를 제공합니다.
  */
-class LoadUserDataService @Inject constructor(
-    private val userUseCaseProvider: UserUseCaseProvider
+class LoadUserDataService(
+    private val userUseCases: UserUseCases
 ) {
-    
-    private val userUseCases: UserUseCases = userUseCaseProvider.createForUser()
     
     data class UserData(
         val userId: UserId,


### PR DESCRIPTION
## Summary
- create services using usecases rather than providers
- introduce project-specific services from `HomeViewModelServiceProvider`
- adjust `HomeViewModel` to request services per user and project
- update services to accept usecases
- fix lint issue in `HomeScreen`

## Testing
- `./gradlew :feature:feature_home:lintDebug :feature:feature_home:test`


------
https://chatgpt.com/codex/tasks/task_e_68762d032cd48325bc80ad7e15526082