### PR TITLE
Add reorder test dialog for edit channel

### DIFF
--- a/feature/feature_edit_channel/src/main/java/com/example/feature_edit_channel/ui/ChannelReorderTestDialog.kt
+++ b/feature/feature_edit_channel/src/main/java/com/example/feature_edit_channel/ui/ChannelReorderTestDialog.kt
@@ -1,0 +1,164 @@
+package com.example.feature_edit_channel.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDownward
+import androidx.compose.material.icons.filled.ArrowUpward
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.example.feature_edit_channel.viewmodel.ChannelReorderTestViewModel
+import com.example.feature_edit_channel.viewmodel.ReorderItem
+
+@Composable
+fun ChannelReorderTestDialog(
+    projectId: String,
+    onDismissRequest: () -> Unit,
+    viewModel: ChannelReorderTestViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(projectId) {
+        viewModel.initialize(projectId)
+    }
+
+    Dialog(
+        onDismissRequest = onDismissRequest,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Surface(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp)
+                .clip(MaterialTheme.shapes.medium),
+            tonalElevation = 8.dp
+        ) {
+            if (uiState.currentCategory == null) {
+                RootReorderContent(
+                    items = uiState.items,
+                    onMoveUp = viewModel::moveItemUp,
+                    onMoveDown = viewModel::moveItemDown,
+                    onCategoryClick = viewModel::onCategorySelected
+                )
+            } else {
+                val category = uiState.currentCategory
+                CategoryChannelReorderContent(
+                    categoryName = category!!.name.value,
+                    channels = uiState.categoryChannels,
+                    onMoveUp = viewModel::moveChannelUp,
+                    onMoveDown = viewModel::moveChannelDown,
+                    onBack = viewModel::onBackToRoot
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RootReorderContent(
+    items: List<ReorderItem>,
+    onMoveUp: (Int) -> Unit,
+    onMoveDown: (Int) -> Unit,
+    onCategoryClick: (ReorderItem.CategoryItem) -> Unit
+) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        Text(
+            text = "프로젝트 구조 테스트",
+            style = MaterialTheme.typography.titleLarge,
+            modifier = Modifier.align(Alignment.CenterHorizontally)
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Divider()
+        LazyColumn(modifier = Modifier.weight(1f)) {
+            itemsIndexed(items) { index, item ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable(enabled = item is ReorderItem.CategoryItem) {
+                            if (item is ReorderItem.CategoryItem) onCategoryClick(item)
+                        }
+                        .padding(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = when (item) {
+                            is ReorderItem.CategoryItem -> "[C] ${'$'}{item.category.name.value}"
+                            is ReorderItem.ChannelItem -> "[Ch] ${'$'}{item.channel.channelName.value}"
+                        },
+                        modifier = Modifier.weight(1f)
+                    )
+                    IconButton(onClick = { onMoveUp(index) }) {
+                        Icon(Icons.Filled.ArrowUpward, contentDescription = "Up")
+                    }
+                    IconButton(onClick = { onMoveDown(index) }) {
+                        Icon(Icons.Filled.ArrowDownward, contentDescription = "Down")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CategoryChannelReorderContent(
+    categoryName: String,
+    channels: List<com.example.domain.model.base.ProjectChannel>,
+    onMoveUp: (Int) -> Unit,
+    onMoveDown: (Int) -> Unit,
+    onBack: () -> Unit
+) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+            IconButton(onClick = onBack) {
+                Icon(Icons.Filled.ArrowUpward, contentDescription = "Back")
+            }
+            Text(
+                text = categoryName,
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.padding(start = 8.dp)
+            )
+        }
+        Divider()
+        LazyColumn(modifier = Modifier.weight(1f)) {
+            itemsIndexed(channels) { index, channel ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = channel.channelName.value,
+                        modifier = Modifier.weight(1f)
+                    )
+                    IconButton(onClick = { onMoveUp(index) }) {
+                        Icon(Icons.Filled.ArrowUpward, contentDescription = "Up")
+                    }
+                    IconButton(onClick = { onMoveDown(index) }) {
+                        Icon(Icons.Filled.ArrowDownward, contentDescription = "Down")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ChannelReorderTestDialogPreview() {
+    ChannelReorderTestDialog(projectId = "test_project", onDismissRequest = {})
+}
+

--- a/feature/feature_edit_channel/src/main/java/com/example/feature_edit_channel/viewmodel/ChannelReorderTestViewModel.kt
+++ b/feature/feature_edit_channel/src/main/java/com/example/feature_edit_channel/viewmodel/ChannelReorderTestViewModel.kt
@@ -1,0 +1,116 @@
+package com.example.feature_edit_channel.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.core_common.result.CustomResult
+import com.example.domain.model.base.Category
+import com.example.domain.model.base.ProjectChannel
+import com.example.domain.model.vo.DocumentId
+import com.example.domain.provider.project.ProjectStructureUseCaseProvider
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+sealed interface ReorderItem {
+    val order: Double
+
+    data class CategoryItem(val category: Category) : ReorderItem {
+        override val order: Double get() = category.order.value
+    }
+
+    data class ChannelItem(val channel: ProjectChannel) : ReorderItem {
+        override val order: Double get() = channel.order.value
+    }
+}
+
+data class ChannelReorderTestUiState(
+    val items: List<ReorderItem> = emptyList(),
+    val currentCategory: Category? = null,
+    val categoryChannels: List<ProjectChannel> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: String? = null
+)
+
+@HiltViewModel
+class ChannelReorderTestViewModel @Inject constructor(
+    private val projectStructureUseCaseProvider: ProjectStructureUseCaseProvider
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(ChannelReorderTestUiState())
+    val uiState: StateFlow<ChannelReorderTestUiState> = _uiState.asStateFlow()
+
+    private var categoryChannelMap: Map<Category, List<ProjectChannel>> = emptyMap()
+
+    fun initialize(projectId: String) {
+        viewModelScope.launch {
+            val useCases = projectStructureUseCaseProvider.createForProject(DocumentId(projectId))
+            useCases.getProjectStructureUseCase(DocumentId(projectId)).collect { result ->
+                when (result) {
+                    is CustomResult.Success -> {
+                        categoryChannelMap = result.data.categoryChannelMap
+                        val items = buildList {
+                            categoryChannelMap.keys.forEach { add(ReorderItem.CategoryItem(it)) }
+                            result.data.directChannels.forEach { add(ReorderItem.ChannelItem(it)) }
+                        }.sortedBy { it.order }
+                        _uiState.update { it.copy(items = items, isLoading = false, error = null) }
+                    }
+                    is CustomResult.Failure -> {
+                        _uiState.update { it.copy(isLoading = false, error = result.error.message) }
+                    }
+                    is CustomResult.Loading -> _uiState.update { it.copy(isLoading = true) }
+                    else -> {}
+                }
+            }
+        }
+    }
+
+    fun onCategorySelected(item: ReorderItem.CategoryItem) {
+        val channels = categoryChannelMap[item.category].orEmpty().sortedBy { it.order.value }
+        _uiState.update { it.copy(currentCategory = item.category, categoryChannels = channels) }
+    }
+
+    fun onBackToRoot() {
+        _uiState.update { it.copy(currentCategory = null, categoryChannels = emptyList()) }
+    }
+
+    fun moveItemUp(index: Int) {
+        val list = _uiState.value.items.toMutableList()
+        if (index <= 0 || index >= list.size) return
+        val tmp = list[index - 1]
+        list[index - 1] = list[index]
+        list[index] = tmp
+        _uiState.update { it.copy(items = list) }
+    }
+
+    fun moveItemDown(index: Int) {
+        val list = _uiState.value.items.toMutableList()
+        if (index < 0 || index >= list.lastIndex) return
+        val tmp = list[index + 1]
+        list[index + 1] = list[index]
+        list[index] = tmp
+        _uiState.update { it.copy(items = list) }
+    }
+
+    fun moveChannelUp(index: Int) {
+        val list = _uiState.value.categoryChannels.toMutableList()
+        if (index <= 0 || index >= list.size) return
+        val tmp = list[index - 1]
+        list[index - 1] = list[index]
+        list[index] = tmp
+        _uiState.update { it.copy(categoryChannels = list) }
+    }
+
+    fun moveChannelDown(index: Int) {
+        val list = _uiState.value.categoryChannels.toMutableList()
+        if (index < 0 || index >= list.lastIndex) return
+        val tmp = list[index + 1]
+        list[index + 1] = list[index]
+        list[index] = tmp
+        _uiState.update { it.copy(categoryChannels = list) }
+    }
+}
+


### PR DESCRIPTION
## Summary
- create `ChannelReorderTestDialog` with simple list reordering
- add `ChannelReorderTestViewModel` to fetch project structure and handle UI state

## Testing
- `./gradlew :feature:feature_edit_channel:lintDebug`
- `./gradlew :feature:feature_edit_channel:test`


------
https://chatgpt.com/codex/tasks/task_e_68762eb0e6e0832592efa766fb79252d